### PR TITLE
fix: file.list accepts 'path' param alias for 'subPath'

### DIFF
--- a/Sources/ClawsyShared/NetworkManager.swift
+++ b/Sources/ClawsyShared/NetworkManager.swift
@@ -1393,7 +1393,7 @@ public class NetworkManager: NSObject, ObservableObject, WebSocketDelegate, UNUs
             
         case "file.list":
             self.sendAck(id: id)
-            let subPath = params["subPath"] as? String ?? ""
+            let subPath = params["subPath"] as? String ?? params["path"] as? String ?? ""
             let recursive = params["recursive"] as? Bool ?? false
             DispatchQueue.global(qos: .userInitiated).async {
                 let files = ClawsyFileManager.listFiles(at: baseDir, subPath: subPath, recursive: recursive)


### PR DESCRIPTION
Ray reported file.list always returning root when called with path='#music'. Root cause: Swift code only read params["subPath"], ignoring the documented 'path' parameter entirely. This commit (63bf288) fixes it by accepting both param names.

Also includes: file.mkdir, file.rmdir, recursive listing support from earlier work on this branch.

Fixes #-prefixed directory navigation for all Clawsy agents.