### PR TITLE
fix: request notification permission on app launch

### DIFF
--- a/Sources/ClawsyMac/ClawsyApp.swift
+++ b/Sources/ClawsyMac/ClawsyApp.swift
@@ -363,6 +363,7 @@ Details in CLAWSY.md.
         // Auto-Check for Updates (silent = background, shows notification if update found)
         UpdateManager.shared.checkForUpdates(silent: true)
         UpdateManager.shared.startPeriodicChecks()
+        UpdateManager.shared.ensureNotificationPermission()
 
         // Redraw menu bar icon when system appearance changes (Dark ↔ Light Mode)
         DistributedNotificationCenter.default().addObserver(

--- a/Sources/ClawsyMac/UpdateManager.swift
+++ b/Sources/ClawsyMac/UpdateManager.swift
@@ -62,7 +62,7 @@ class UpdateManager: ObservableObject {
     // MARK: - Notification Permission
     
     /// Request notification permission independently (may run before NetworkManager).
-    private func ensureNotificationPermission() {
+    func ensureNotificationPermission() {
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { granted, error in
             if let error = error {
                 print("⚠️ Notification permission error: \(error)")


### PR DESCRIPTION
## Problem
`ensureNotificationPermission()` in `UpdateManager.swift` was `private` and never called from outside the class. macOS was therefore never prompted for notification authorization — the 4h update timer ran, but notifications silently failed when an update was found.

## Fix (minimal-invasive)
- Remove `private` from `ensureNotificationPermission()` (now internal)
- Call `UpdateManager.shared.ensureNotificationPermission()` in `applicationDidFinishLaunching`, right after `startPeriodicChecks()`

No rename, no API break. Two lines changed.