### PR TITLE
feat: Onboarding UX — 3 Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,24 @@ Nothing happens behind your back. Every screenshot, clipboard read, or file writ
 
 ---
 
-## Quick Start
+## Getting Started
+
+The easiest way to set up Clawsy:
+
+1. **Download & install** Clawsy on your Mac ([latest release](https://github.com/iret77/clawsy/releases/latest))
+2. **Tell your OpenClaw agent:**
+
+   > "Install the Clawsy skill from clawhub"
+
+3. Your agent will install everything automatically and send you a pairing link — just click it.
+
+**That's it.** Clawsy connects, your agent gets access to screenshots, clipboard, camera, and files.
+
+---
+
+## Manual Setup (Advanced)
+
+If you prefer to configure everything yourself, follow the steps below.
 
 ### 1. Prepare your OpenClaw Gateway
 

--- a/Sources/ClawsyMac/ContentView.swift
+++ b/Sources/ClawsyMac/ContentView.swift
@@ -2074,6 +2074,7 @@ struct AddHostSheet: View {
     @State private var useSshFallback = true
     @State private var selectedColor = HostProfile.defaultColors[1] // Blue default
     @State private var sharedFolderPath = ""
+    @State private var manualHintCopied = false
 
     private var canSave: Bool {
         !host.trimmingCharacters(in: .whitespaces).isEmpty &&
@@ -2192,6 +2193,52 @@ struct AddHostSheet: View {
                             .disabled(!useSshFallback)
                             .opacity(useSshFallback ? 1.0 : 0.5)
                     }
+
+                    // Agent assist hint — subtle alternative for users who don't have connection details
+                    VStack(alignment: .leading, spacing: 8) {
+                        Divider().opacity(0.3)
+
+                        Text(l10n: "ADD_HOST_MANUAL_HINT_TITLE")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundColor(.secondary)
+
+                        Text(l10n: "ADD_HOST_MANUAL_HINT_DESC")
+                            .font(.system(size: 11))
+                            .foregroundColor(.secondary)
+
+                        Button(action: {
+                            let prompt = NSLocalizedString("ADD_HOST_MANUAL_HINT_PROMPT", bundle: .clawsy, comment: "")
+                            NSPasteboard.general.clearContents()
+                            NSPasteboard.general.setString(prompt, forType: .string)
+                            manualHintCopied = true
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                                manualHintCopied = false
+                            }
+                        }) {
+                            HStack(spacing: 6) {
+                                Text(l10n: "ADD_HOST_MANUAL_HINT_PROMPT")
+                                    .font(.system(size: 11, design: .monospaced))
+                                    .foregroundColor(.primary.opacity(0.85))
+                                Spacer(minLength: 4)
+                                Image(systemName: manualHintCopied ? "checkmark" : "doc.on.clipboard")
+                                    .font(.system(size: 11))
+                                    .foregroundColor(manualHintCopied ? .green : .secondary)
+                            }
+                            .padding(8)
+                            .background(Color(nsColor: .textBackgroundColor).opacity(0.5))
+                            .cornerRadius(6)
+                            .overlay(RoundedRectangle(cornerRadius: 6)
+                                .strokeBorder(Color.secondary.opacity(0.2), lineWidth: 1))
+                        }
+                        .buttonStyle(.plain)
+
+                        if manualHintCopied {
+                            Text(l10n: "ADD_HOST_MANUAL_HINT_COPIED")
+                                .font(.system(size: 10))
+                                .foregroundColor(.green)
+                        }
+                    }
+                    .padding(.top, 8)
                 }
                 .padding(20)
             } // end ScrollView (manual)

--- a/Sources/ClawsyMac/Resources/de.lproj/Localizable.strings
+++ b/Sources/ClawsyMac/Resources/de.lproj/Localizable.strings
@@ -317,3 +317,15 @@
 "CONNECTION_GUIDE_STEP1" = "Sag deinem Agenten: \"Installiere das Clawsy-Serverpaket\" (clawhub install clawsy)";
 "CONNECTION_GUIDE_STEP2" = "Dein Agent schickt dir einen Verbindungslink – klick ihn an und Clawsy verbindet sich automatisch.";
 "STATUS_RECONNECT_COUNTDOWN %lld" = "Neuverbindung in %lld s…";
+
+// Onboarding UX — Skill fehlt nach SSH (v0.9.4)
+"ERROR_SKILL_MISSING_TITLE" = "SSH verbunden — Clawsy-Skill fehlt";
+"ERROR_SKILL_MISSING_DESC" = "SSH-Verbindung erfolgreich — aber der Clawsy-Server-Skill ist auf dieser OpenClaw-Instanz nicht installiert.";
+"ERROR_SKILL_MISSING_FIX_PROMPT" = "Installiere den Clawsy-Skill von clawhub";
+
+// Host hinzufügen — Agent-Hilfe-Hinweis im manuellen Modus
+"ADD_HOST_MANUAL_HINT_TITLE" = "Verbindungsdaten unbekannt?";
+"ADD_HOST_MANUAL_HINT_DESC" = "Sag deinem OpenClaw-Agenten:";
+"ADD_HOST_MANUAL_HINT_PROMPT" = "Installiere den Clawsy-Skill von clawhub";
+"ADD_HOST_MANUAL_HINT_COPY" = "Kopieren";
+"ADD_HOST_MANUAL_HINT_COPIED" = "Kopiert!";

--- a/Sources/ClawsyMac/Resources/en.lproj/Localizable.strings
+++ b/Sources/ClawsyMac/Resources/en.lproj/Localizable.strings
@@ -316,3 +316,15 @@
 "CONNECTION_GUIDE_STEP1" = "Tell your agent: \"Install the Clawsy server package\" (clawhub install clawsy)";
 "CONNECTION_GUIDE_STEP2" = "Your agent will send you a setup link — click it and Clawsy connects automatically.";
 "STATUS_RECONNECT_COUNTDOWN %lld" = "Reconnecting in %lld s…";
+
+// Onboarding UX — Skill missing after SSH (v0.9.4)
+"ERROR_SKILL_MISSING_TITLE" = "SSH connected — Clawsy skill missing";
+"ERROR_SKILL_MISSING_DESC" = "SSH connection successful — but the Clawsy server skill is not installed on this OpenClaw instance.";
+"ERROR_SKILL_MISSING_FIX_PROMPT" = "Install the Clawsy skill from clawhub";
+
+// Add Host — agent assist hint in manual mode
+"ADD_HOST_MANUAL_HINT_TITLE" = "Don't know your connection details?";
+"ADD_HOST_MANUAL_HINT_DESC" = "Tell your OpenClaw agent:";
+"ADD_HOST_MANUAL_HINT_PROMPT" = "Install the Clawsy skill from clawhub";
+"ADD_HOST_MANUAL_HINT_COPY" = "Copy";
+"ADD_HOST_MANUAL_HINT_COPIED" = "Copied!";

--- a/Sources/ClawsyShared/ConnectionError.swift
+++ b/Sources/ClawsyShared/ConnectionError.swift
@@ -9,6 +9,7 @@ public enum ConnectionError: Equatable {
     case hostUnreachable
     case gatewayNotRunning
     case reconnectExhausted
+    case skillMissingAfterSsh
     case unknownDisconnect(reason: String)
 
     // MARK: - User-Facing Strings (German)
@@ -21,6 +22,7 @@ public enum ConnectionError: Equatable {
         case .hostUnreachable:      return "Gateway nicht erreichbar"
         case .gatewayNotRunning:    return "Gateway antwortet nicht"
         case .reconnectExhausted:   return "Verbindung fehlgeschlagen"
+        case .skillMissingAfterSsh: return NSLocalizedString("ERROR_SKILL_MISSING_TITLE", bundle: .clawsy, comment: "")
         case .unknownDisconnect:    return "Verbindungsfehler"
         }
     }
@@ -39,6 +41,8 @@ public enum ConnectionError: Equatable {
             return "Der SSH-Tunnel steht, aber das Gateway antwortet nicht auf localhost."
         case .reconnectExhausted:
             return "Verbindung konnte nach mehreren Versuchen nicht hergestellt werden. Bitte Netzwerk und Gateway-Einstellungen prüfen."
+        case .skillMissingAfterSsh:
+            return NSLocalizedString("ERROR_SKILL_MISSING_DESC", bundle: .clawsy, comment: "")
         case .unknownDisconnect(let reason):
             return "Verbindung getrennt: \(reason)"
         }
@@ -73,6 +77,8 @@ public enum ConnectionError: Equatable {
             Mein Clawsy hat einen SSH-Tunnel aufgebaut, aber das Gateway antwortet nicht auf localhost. \
             Bitte prüfe ob das OpenClaw Gateway auf dem Server läuft (`openclaw gateway status`).
             """
+        case .skillMissingAfterSsh:
+            return NSLocalizedString("ERROR_SKILL_MISSING_FIX_PROMPT", bundle: .clawsy, comment: "")
         case .reconnectExhausted:
             return nil
         case .unknownDisconnect:
@@ -91,6 +97,11 @@ public enum ConnectionError: Equatable {
             return .openSettings  // User can also copy the prompt, but settings is primary
         case .sshTunnelFailed:
             return .openSettings
+        case .skillMissingAfterSsh:
+            if let prompt = fixPrompt {
+                return .copyPromptToClipboard(prompt)
+            }
+            return .none
         case .reconnectExhausted:
             return .openSettings
         case .unknownDisconnect:

--- a/Sources/ClawsyShared/NetworkManager.swift
+++ b/Sources/ClawsyShared/NetworkManager.swift
@@ -1296,7 +1296,13 @@ public class NetworkManager: NSObject, ObservableObject, WebSocketDelegate, UNUs
                      self.disconnectReason = .setupFailed(errorCode)
                      self.isHandshakeComplete = false
                      self.connectionStatus = "STATUS_HANDSHAKE_FAILED"
-                     self.connectionError = .invalidToken
+                     // If we got here via SSH tunnel, the gateway is reachable but the
+                     // Clawsy server skill is likely not installed — show a specific hint.
+                     if self.isUsingSshTunnel {
+                         self.connectionError = .skillMissingAfterSsh
+                     } else {
+                         self.connectionError = .invalidToken
+                     }
                 } else if let errorObj = json["error"] as? [String: Any],
                           let errorCode = errorObj["code"] as? String,
                           errorCode == "INVALID_REQUEST" {

--- a/Sources/ClawsyShared/Resources/de.lproj/Localizable.strings
+++ b/Sources/ClawsyShared/Resources/de.lproj/Localizable.strings
@@ -322,3 +322,15 @@
 "CONNECTION_GUIDE_STEP1" = "Sag deinem Agenten: \"Installiere das Clawsy-Serverpaket\" (clawhub install clawsy)";
 "CONNECTION_GUIDE_STEP2" = "Dein Agent schickt dir einen Verbindungslink – klick ihn an und Clawsy verbindet sich automatisch.";
 "STATUS_RECONNECT_COUNTDOWN %lld" = "Neuverbindung in %lld s…";
+
+// Onboarding UX — Skill fehlt nach SSH (v0.9.4)
+"ERROR_SKILL_MISSING_TITLE" = "SSH verbunden — Clawsy-Skill fehlt";
+"ERROR_SKILL_MISSING_DESC" = "SSH-Verbindung erfolgreich — aber der Clawsy-Server-Skill ist auf dieser OpenClaw-Instanz nicht installiert.";
+"ERROR_SKILL_MISSING_FIX_PROMPT" = "Installiere den Clawsy-Skill von clawhub";
+
+// Host hinzufügen — Agent-Hilfe-Hinweis im manuellen Modus
+"ADD_HOST_MANUAL_HINT_TITLE" = "Verbindungsdaten unbekannt?";
+"ADD_HOST_MANUAL_HINT_DESC" = "Sag deinem OpenClaw-Agenten:";
+"ADD_HOST_MANUAL_HINT_PROMPT" = "Installiere den Clawsy-Skill von clawhub";
+"ADD_HOST_MANUAL_HINT_COPY" = "Kopieren";
+"ADD_HOST_MANUAL_HINT_COPIED" = "Kopiert!";

--- a/Sources/ClawsyShared/Resources/en.lproj/Localizable.strings
+++ b/Sources/ClawsyShared/Resources/en.lproj/Localizable.strings
@@ -321,3 +321,15 @@
 "CONNECTION_GUIDE_STEP1" = "Tell your agent: \"Install the Clawsy server package\" (clawhub install clawsy)";
 "CONNECTION_GUIDE_STEP2" = "Your agent will send you a setup link — click it and Clawsy connects automatically.";
 "STATUS_RECONNECT_COUNTDOWN %lld" = "Reconnecting in %lld s…";
+
+// Onboarding UX — Skill missing after SSH (v0.9.4)
+"ERROR_SKILL_MISSING_TITLE" = "SSH connected — Clawsy skill missing";
+"ERROR_SKILL_MISSING_DESC" = "SSH connection successful — but the Clawsy server skill is not installed on this OpenClaw instance.";
+"ERROR_SKILL_MISSING_FIX_PROMPT" = "Install the Clawsy skill from clawhub";
+
+// Add Host — agent assist hint in manual mode
+"ADD_HOST_MANUAL_HINT_TITLE" = "Don't know your connection details?";
+"ADD_HOST_MANUAL_HINT_DESC" = "Tell your OpenClaw agent:";
+"ADD_HOST_MANUAL_HINT_PROMPT" = "Install the Clawsy skill from clawhub";
+"ADD_HOST_MANUAL_HINT_COPY" = "Copy";
+"ADD_HOST_MANUAL_HINT_COPIED" = "Copied!";

--- a/Sources/ClawsyShared/Resources/es.lproj/Localizable.strings
+++ b/Sources/ClawsyShared/Resources/es.lproj/Localizable.strings
@@ -134,3 +134,15 @@
 "SSH_ONLY_MODE" = "Solo SSH";
 "SSH_ONLY_MODE_DESC" = "Omitir conexión directa, siempre usar túnel SSH";
 "STATUS_RECONNECT_COUNTDOWN %lld" = "Reconectando en %lld s…";
+
+// Onboarding UX — Skill missing after SSH (v0.9.4)
+"ERROR_SKILL_MISSING_TITLE" = "SSH connected — Clawsy skill missing";
+"ERROR_SKILL_MISSING_DESC" = "SSH connection successful — but the Clawsy server skill is not installed on this OpenClaw instance.";
+"ERROR_SKILL_MISSING_FIX_PROMPT" = "Install the Clawsy skill from clawhub";
+
+// Add Host — agent assist hint in manual mode
+"ADD_HOST_MANUAL_HINT_TITLE" = "Don't know your connection details?";
+"ADD_HOST_MANUAL_HINT_DESC" = "Tell your OpenClaw agent:";
+"ADD_HOST_MANUAL_HINT_PROMPT" = "Install the Clawsy skill from clawhub";
+"ADD_HOST_MANUAL_HINT_COPY" = "Copy";
+"ADD_HOST_MANUAL_HINT_COPIED" = "Copied!";

--- a/Sources/ClawsyShared/Resources/fr.lproj/Localizable.strings
+++ b/Sources/ClawsyShared/Resources/fr.lproj/Localizable.strings
@@ -134,3 +134,15 @@
 "SSH_ONLY_MODE" = "SSH uniquement";
 "SSH_ONLY_MODE_DESC" = "Ignorer la connexion directe, toujours utiliser le tunnel SSH";
 "STATUS_RECONNECT_COUNTDOWN %lld" = "Reconnexion dans %lld s…";
+
+// Onboarding UX — Skill missing after SSH (v0.9.4)
+"ERROR_SKILL_MISSING_TITLE" = "SSH connected — Clawsy skill missing";
+"ERROR_SKILL_MISSING_DESC" = "SSH connection successful — but the Clawsy server skill is not installed on this OpenClaw instance.";
+"ERROR_SKILL_MISSING_FIX_PROMPT" = "Install the Clawsy skill from clawhub";
+
+// Add Host — agent assist hint in manual mode
+"ADD_HOST_MANUAL_HINT_TITLE" = "Don't know your connection details?";
+"ADD_HOST_MANUAL_HINT_DESC" = "Tell your OpenClaw agent:";
+"ADD_HOST_MANUAL_HINT_PROMPT" = "Install the Clawsy skill from clawhub";
+"ADD_HOST_MANUAL_HINT_COPY" = "Copy";
+"ADD_HOST_MANUAL_HINT_COPIED" = "Copied!";


### PR DESCRIPTION
## Clawsy Onboarding UX — 3 Fixes

### Task 1: README — Getting Started section
Added a prominent `Getting Started` section at the top of README.md with simple agent-driven setup:
> "Install the Clawsy skill from clawhub"

This is now the **first instruction** a new user sees — before any manual configuration details.

### Task 2: Better error UX for token mismatch after SSH success
New `ConnectionError.skillMissingAfterSsh` case. When `AUTH_TOKEN_MISMATCH` occurs over an active SSH tunnel, Clawsy now shows a **specific, helpful error banner**:
- "SSH connection successful — but the Clawsy server skill is missing"
- With copy-to-clipboard fix prompt directing user to install the skill

Instead of the previous generic "Authentifizierungsfehler".

### Task 3: Agent assist hint in Add Host manual dialog
Below the manual input fields (Host, Token, SSH), there's now a subtle hint section:
- "Don't know your connection details?"
- "Tell your OpenClaw agent: Install the Clawsy skill from clawhub"
- With copy button

Visually understated (secondary colors, smaller font) so advanced users aren't distracted.

### Localization
All new strings added to all 4 locales (en, de, fr, es) in both ClawsyMac and ClawsyShared resource bundles. FR+ES use English text as per convention.