### PR TITLE
feat: file.move command with path sandboxing

### DIFF
--- a/Sources/ClawsyShared/ClawsyFileManager.swift
+++ b/Sources/ClawsyShared/ClawsyFileManager.swift
@@ -138,4 +138,76 @@ public class ClawsyFileManager {
             return false
         }
     }
+
+    // MARK: - Path Sandboxing
+
+    /// Resolves a relative path against the base directory and validates it stays within the sandbox.
+    /// Returns the resolved absolute path, or nil if the path escapes the base directory.
+    public static func sandboxedPath(base: String, relativePath: String) -> String? {
+        let baseURL = URL(fileURLWithPath: base).standardized
+        let resolvedURL = baseURL.appendingPathComponent(relativePath).standardized
+        let basePath = baseURL.path.hasSuffix("/") ? baseURL.path : baseURL.path + "/"
+        let resolvedPath = resolvedURL.path
+        // The resolved path must start with the base path, or be exactly the base path (without trailing slash)
+        guard resolvedPath == baseURL.path || resolvedPath.hasPrefix(basePath) else {
+            return nil
+        }
+        return resolvedPath
+    }
+
+    // MARK: - Move File/Directory
+
+    public enum MoveError: Error, CustomStringConvertible {
+        case sourceNotFound
+        case destinationExists
+        case pathTraversal
+        case moveFailed(String)
+
+        public var description: String {
+            switch self {
+            case .sourceNotFound: return "Source file or directory not found"
+            case .destinationExists: return "Destination already exists"
+            case .pathTraversal: return "Path must stay within the shared folder"
+            case .moveFailed(let reason): return "Move failed: \(reason)"
+            }
+        }
+    }
+
+    /// Moves a file or directory within the shared folder.
+    /// Both source and destination are validated to stay within baseDir.
+    /// Intermediate directories at the destination are created automatically.
+    public static func moveFile(baseDir: String, source: String, destination: String) -> Result<Void, MoveError> {
+        let fileManager = Foundation.FileManager.default
+
+        guard let sourcePath = sandboxedPath(base: baseDir, relativePath: source) else {
+            return .failure(.pathTraversal)
+        }
+        guard let destPath = sandboxedPath(base: baseDir, relativePath: destination) else {
+            return .failure(.pathTraversal)
+        }
+
+        guard fileManager.fileExists(atPath: sourcePath) else {
+            return .failure(.sourceNotFound)
+        }
+        if fileManager.fileExists(atPath: destPath) {
+            return .failure(.destinationExists)
+        }
+
+        // Create intermediate directories at destination (mkdir -p)
+        let destParent = (destPath as NSString).deletingLastPathComponent
+        if !fileManager.fileExists(atPath: destParent) {
+            do {
+                try fileManager.createDirectory(atPath: destParent, withIntermediateDirectories: true, attributes: nil)
+            } catch {
+                return .failure(.moveFailed("Failed to create destination directory: \(error.localizedDescription)"))
+            }
+        }
+
+        do {
+            try fileManager.moveItem(atPath: sourcePath, toPath: destPath)
+            return .success(())
+        } catch {
+            return .failure(.moveFailed(error.localizedDescription))
+        }
+    }
 }

--- a/Sources/ClawsyShared/NetworkManager.swift
+++ b/Sources/ClawsyShared/NetworkManager.swift
@@ -1411,7 +1411,7 @@ public class NetworkManager: NSObject, ObservableObject, WebSocketDelegate, UNUs
                 "client": ["id": connectClientId, "version": SharedConfig.versionDisplay, "platform": Self.connectPlatform, "mode": Self.connectClientMode],
                 "role": Self.connectRole, "caps": ["clipboard", "screen", "camera", "file", "location"],
                 "scopes": Self.connectScopes,
-                "commands": ["clipboard.read", "clipboard.write", "screen.capture", "camera.list", "camera.snap", "file.list", "file.get", "file.set", "file.get.chunk", "file.set.chunk", "file.delete", "file.rename", "file.mkdir", "file.rmdir", "location.get", "location.start", "location.stop", "location.add_smart"],
+                "commands": ["clipboard.read", "clipboard.write", "screen.capture", "camera.list", "camera.snap", "file.list", "file.get", "file.set", "file.get.chunk", "file.set.chunk", "file.delete", "file.rename", "file.move", "file.mkdir", "file.rmdir", "location.get", "location.start", "location.stop", "location.add_smart"],
                 "permissions": ["clipboard.read": true, "clipboard.write": true],
                 "auth": ["token": authToken],
                 "device": [
@@ -1630,6 +1630,31 @@ public class NetworkManager: NSObject, ObservableObject, WebSocketDelegate, UNUs
                 let success = ClawsyFileManager.createDirectory(at: fullPathMkdir)
                 self.sendResponse(id: id, result: ["success": success, "name": name])
             }
+        case "file.move":
+            guard let source = params["source"] as? String, let destination = params["destination"] as? String else {
+                sendError(id: id, code: -32602, message: "Missing 'source' or 'destination' parameter"); return
+            }
+            self.sendAck(id: id)
+            let executeMove = {
+                self.notifyAction(title: NSLocalizedString("NOTIFICATION_TITLE", bundle: .clawsy, comment: ""), body: "Moved: \(source) → \(destination)", isAuto: ({ if let exp = self.filePermissionExpiry { return exp > Date() } else { return false } }()))
+                DispatchQueue.global(qos: .userInitiated).async {
+                    let result = ClawsyFileManager.moveFile(baseDir: baseDir, source: source, destination: destination)
+                    switch result {
+                    case .success:
+                        self.sendResponse(id: id, result: ["status": "ok", "source": source, "destination": destination])
+                    case .failure(let error):
+                        let code: Int
+                        switch error {
+                        case .sourceNotFound: code = -32001
+                        case .destinationExists: code = -32002
+                        case .pathTraversal: code = -32003
+                        case .moveFailed: code = -32000
+                        }
+                        self.sendError(id: id, code: code, message: error.description)
+                    }
+                }
+            }
+            if let expiry = filePermissionExpiry, expiry > Date() { executeMove() } else { onFileSyncRequested?(source, "Move to \(destination)", { duration in if let duration = duration { self.filePermissionExpiry = Date().addingTimeInterval(duration) }; executeMove() }, { self.sendError(id: id, code: -1, message: "User denied file move") }) }
         case "file.rename":
             guard let name = params["name"] as? String, let newName = params["newName"] as? String else { sendError(id: id, code: -32602, message: "Missing 'name' or 'newName' parameter"); return }
             let fullPath = (baseDir as NSString).appendingPathComponent(name)


### PR DESCRIPTION
## Summary
Adds `file.move` command to move files and directories within the shared folder.

## Changes

### ClawsyFileManager.swift
- **`sandboxedPath(base:relativePath:)`** — Reusable path sandboxing utility. Resolves a relative path against a base directory and validates it stays within bounds. Returns `nil` for path traversal attempts (`../`).
- **`MoveError` enum** — Typed errors: `.sourceNotFound`, `.destinationExists`, `.pathTraversal`, `.moveFailed(String)`
- **`moveFile(baseDir:source:destination:)`** — Core move logic with full validation and auto-creation of intermediate destination directories.

### NetworkManager.swift
- `file.move` registered in hello handshake `commands` list
- `file.move` case in `handleCommand` — follows existing permission dialog pattern (`onFileSyncRequested`)
- Distinct error codes: `-32001` (not found), `-32002` (exists), `-32003` (path traversal), `-32000` (general)

## Usage
```json
{ "command": "file.move", "params": { "source": "old/path/file.txt", "destination": "new/path/file.txt" } }
```
Both paths are relative to the shared folder. Path traversal (`../../etc/passwd`) is rejected.

## Gateway Allowlist
⚠️ `file.move` needs to be added to `gateway.nodes.allowCommands` after merge.