### PR TITLE
feat: File-API v2 — new commands, glob support, batch ops

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -110,6 +110,10 @@ bash scripts/clawsy-pair.sh
 | **File List** | `file.list` | List files in the shared folder |
 | **File Read** | `file.get` | Read a file from the shared folder |
 | **File Write** | `file.set` | Write a file to the shared folder |
+| **File Copy** | `file.copy` | Copy files (supports glob patterns like `*.jpg`) |
+| **File Stat** | `file.stat` | Get file metadata (size, dates, type) |
+| **File Exists** | `file.exists` | Quick existence check |
+| **File Batch** | `file.batch` | Multiple file ops in a single call |
 | **Location** | `location.get` | Get device location |
 | **Mission Control** | via `agent.status` | Show live task progress in Clawsy UI |
 | **Quick Send** | incoming | Receive text from user via `⌘⇧K` hotkey |
@@ -157,6 +161,55 @@ nodes(action="invoke", invokeCommand="location.get")
 ```
 
 > **Note:** All commands that access user data (screenshot, clipboard, camera, files) require user approval on the Mac side. The user sees a permission dialog and can allow once, allow for 1 hour, or deny.
+
+### New File Commands (v0.10+)
+
+```python
+# Copy a file
+nodes(action="invoke", invokeCommand="file.copy",
+      invokeParamsJson='{"source": "report.pdf", "destination": "archive/report.pdf"}')
+
+# Copy with glob pattern — destination must be a directory
+nodes(action="invoke", invokeCommand="file.copy",
+      invokeParamsJson='{"source": "*.jpg", "destination": "photos/"}')
+
+# Rename a file (newName = filename only, no path)
+nodes(action="invoke", invokeCommand="file.rename",
+      invokeParamsJson='{"path": "old-name.txt", "newName": "new-name.txt"}')
+
+# File stat — get metadata
+nodes(action="invoke", invokeCommand="file.stat",
+      invokeParamsJson='{"path": "report.pdf"}')
+# → {"exists": true, "isDirectory": false, "size": 12345, "modified": "2026-...", "created": "2026-..."}
+
+# File exists — quick check
+nodes(action="invoke", invokeCommand="file.exists",
+      invokeParamsJson='{"path": "photos/cover.jpg"}')
+# → {"exists": true, "isDirectory": false}
+
+# Delete with glob
+nodes(action="invoke", invokeCommand="file.delete",
+      invokeParamsJson='{"name": "tmp_*"}')
+# → {"status": "ok", "matched": 3, "success": 3, "errors": []}
+
+# Move with glob
+nodes(action="invoke", invokeCommand="file.move",
+      invokeParamsJson='{"source": "*.jpg", "destination": "photos/"}')
+
+# Batch operations — multiple ops in one call
+nodes(action="invoke", invokeCommand="file.batch",
+      invokeParamsJson='{"ops": [{"op": "copy", "src": "cover.png", "dst": "archive/cover-bak.png"}, {"op": "delete", "src": "tmp_*"}, {"op": "mkdir", "dst": "new-folder/"}, {"op": "rename", "path": "old.txt", "newName": "new.txt"}, {"op": "stat", "path": "photos/"}]}')
+```
+
+### Glob Pattern Support
+
+Commands `file.move`, `file.copy`, and `file.delete` support glob patterns:
+- `*` matches any characters (except `/`)
+- `?` matches exactly one character
+- Examples: `*.jpg`, `tmp_*`, `photo?.png`
+- For move/copy with globs: destination must be a directory
+- All matched paths are validated against the sandbox
+- Response includes `matched`, `success`, and `errors` counts
 
 ---
 
@@ -369,6 +422,42 @@ Mac (Clawsy) ─── WSS ───▶ OpenClaw Gateway (Port 18789)
 | **FinderSync** | System Settings → Privacy → Extensions → Finder |
 | **Share Extension** | App must be in `/Applications` |
 | **Global Hotkeys** | System Settings → Privacy → Accessibility |
+
+---
+
+## Gateway allowCommands Sync
+
+The OpenClaw Gateway has a `gateway.nodes.allowCommands` config that restricts which commands nodes can execute. Clawsy sends its full command list during the hello handshake (the `commands` array in the connect request).
+
+### After Pairing a New Clawsy Node
+
+The gateway **may** need its `allowCommands` updated to include the new file commands. **Do NOT modify gateway config automatically** — this is a security-sensitive setting.
+
+Instead, check and suggest:
+
+```bash
+# Check current allowCommands
+cat ~/.openclaw/openclaw.json | python3 -c "
+import json, sys
+cfg = json.load(sys.stdin)
+allowed = cfg.get('gateway', {}).get('nodes', {}).get('allowCommands', [])
+print('Current allowCommands:', allowed if allowed else '(not set = all allowed)')
+"
+```
+
+If `allowCommands` is set (non-empty array), the following commands need to be included for full Clawsy functionality:
+
+```
+clipboard.read, clipboard.write, screen.capture, camera.list, camera.snap,
+file.list, file.get, file.set, file.get.chunk, file.set.chunk,
+file.delete, file.rename, file.move, file.copy, file.mkdir, file.rmdir,
+file.stat, file.exists, file.batch,
+location.get, location.start, location.stop, location.add_smart
+```
+
+If `allowCommands` is empty or not set, all commands are allowed by default — no action needed.
+
+> **Security note:** Always show the user what commands will be allowed and get confirmation before suggesting any config changes.
 
 ---
 

--- a/Sources/ClawsyShared/ClawsyFileManager.swift
+++ b/Sources/ClawsyShared/ClawsyFileManager.swift
@@ -155,7 +155,7 @@ public class ClawsyFileManager {
         return resolvedPath
     }
 
-    // MARK: - Move File/Directory
+    // MARK: - File Operation Errors
 
     public enum MoveError: Error, CustomStringConvertible {
         case sourceNotFound
@@ -172,6 +172,8 @@ public class ClawsyFileManager {
             }
         }
     }
+
+    // MARK: - Move File/Directory
 
     /// Moves a file or directory within the shared folder.
     /// Both source and destination are validated to stay within baseDir.
@@ -209,5 +211,196 @@ public class ClawsyFileManager {
         } catch {
             return .failure(.moveFailed(error.localizedDescription))
         }
+    }
+
+    // MARK: - Copy File/Directory
+
+    /// Copies a file or directory within the shared folder.
+    /// Both source and destination are validated to stay within baseDir.
+    /// Intermediate directories at the destination are created automatically.
+    public static func copyFile(baseDir: String, source: String, destination: String) -> Result<Void, MoveError> {
+        let fileManager = Foundation.FileManager.default
+
+        guard let sourcePath = sandboxedPath(base: baseDir, relativePath: source) else {
+            return .failure(.pathTraversal)
+        }
+        guard let destPath = sandboxedPath(base: baseDir, relativePath: destination) else {
+            return .failure(.pathTraversal)
+        }
+
+        guard fileManager.fileExists(atPath: sourcePath) else {
+            return .failure(.sourceNotFound)
+        }
+        if fileManager.fileExists(atPath: destPath) {
+            return .failure(.destinationExists)
+        }
+
+        let destParent = (destPath as NSString).deletingLastPathComponent
+        if !fileManager.fileExists(atPath: destParent) {
+            do {
+                try fileManager.createDirectory(atPath: destParent, withIntermediateDirectories: true, attributes: nil)
+            } catch {
+                return .failure(.moveFailed("Failed to create destination directory: \(error.localizedDescription)"))
+            }
+        }
+
+        do {
+            try fileManager.copyItem(atPath: sourcePath, toPath: destPath)
+            return .success(())
+        } catch {
+            return .failure(.moveFailed("Copy failed: \(error.localizedDescription)"))
+        }
+    }
+
+    // MARK: - Rename with Sandboxing
+
+    /// Renames a file or directory within the shared folder.
+    /// The new name must be a plain filename (no path separators).
+    /// Both old and new paths are validated to stay within baseDir.
+    public static func renameFile(baseDir: String, path: String, newName: String) -> Result<Void, MoveError> {
+        // newName must not contain path separators
+        guard !newName.contains("/") && !newName.contains("..") else {
+            return .failure(.pathTraversal)
+        }
+
+        guard let sourcePath = sandboxedPath(base: baseDir, relativePath: path) else {
+            return .failure(.pathTraversal)
+        }
+
+        let parentDir = (sourcePath as NSString).deletingLastPathComponent
+        let destPath = (parentDir as NSString).appendingPathComponent(newName)
+
+        // Validate destination stays in sandbox
+        let baseURL = URL(fileURLWithPath: baseDir).standardized
+        let destURL = URL(fileURLWithPath: destPath).standardized
+        let basePth = baseURL.path.hasSuffix("/") ? baseURL.path : baseURL.path + "/"
+        guard destURL.path == baseURL.path || destURL.path.hasPrefix(basePth) else {
+            return .failure(.pathTraversal)
+        }
+
+        let fileManager = Foundation.FileManager.default
+        guard fileManager.fileExists(atPath: sourcePath) else {
+            return .failure(.sourceNotFound)
+        }
+        if fileManager.fileExists(atPath: destPath) {
+            return .failure(.destinationExists)
+        }
+
+        do {
+            try fileManager.moveItem(atPath: sourcePath, toPath: destPath)
+            return .success(())
+        } catch {
+            return .failure(.moveFailed("Rename failed: \(error.localizedDescription)"))
+        }
+    }
+
+    // MARK: - File Stat
+
+    /// Returns metadata for a file or directory within the shared folder.
+    public static func statFile(baseDir: String, relativePath: String) -> [String: Any] {
+        guard let fullPath = sandboxedPath(base: baseDir, relativePath: relativePath) else {
+            return ["exists": false, "error": "Path must stay within the shared folder"]
+        }
+
+        let fileManager = Foundation.FileManager.default
+        var isDir: ObjCBool = false
+        guard fileManager.fileExists(atPath: fullPath, isDirectory: &isDir) else {
+            return ["exists": false]
+        }
+
+        let url = URL(fileURLWithPath: fullPath)
+        let keys: Set<URLResourceKey> = [.fileSizeKey, .contentModificationDateKey, .creationDateKey]
+        guard let values = try? url.resourceValues(forKeys: keys) else {
+            return ["exists": true, "isDirectory": isDir.boolValue]
+        }
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        var result: [String: Any] = [
+            "exists": true,
+            "isDirectory": isDir.boolValue,
+            "size": Int64(values.fileSize ?? 0)
+        ]
+        if let modified = values.contentModificationDate {
+            result["modified"] = formatter.string(from: modified)
+        }
+        if let created = values.creationDate {
+            result["created"] = formatter.string(from: created)
+        }
+        return result
+    }
+
+    // MARK: - File Exists
+
+    /// Quick existence check for a path within the shared folder.
+    public static func existsFile(baseDir: String, relativePath: String) -> [String: Any] {
+        guard let fullPath = sandboxedPath(base: baseDir, relativePath: relativePath) else {
+            return ["exists": false, "error": "Path must stay within the shared folder"]
+        }
+
+        let fileManager = Foundation.FileManager.default
+        var isDir: ObjCBool = false
+        let exists = fileManager.fileExists(atPath: fullPath, isDirectory: &isDir)
+        return ["exists": exists, "isDirectory": exists ? isDir.boolValue : false]
+    }
+
+    // MARK: - Glob Pattern Matching
+
+    /// Returns true if the pattern contains glob characters (* or ?).
+    public static func isGlobPattern(_ pattern: String) -> Bool {
+        return pattern.contains("*") || pattern.contains("?")
+    }
+
+    /// Matches a filename against a glob pattern using * and ? wildcards.
+    /// * matches zero or more characters (except /).
+    /// ? matches exactly one character (except /).
+    public static func globMatch(pattern: String, filename: String) -> Bool {
+        // Use NSPredicate LIKE which supports * and ? natively
+        let predicate = NSPredicate(format: "SELF LIKE %@", pattern)
+        return predicate.evaluate(with: filename)
+    }
+
+    /// Resolves a glob pattern against the shared folder contents.
+    /// The pattern's directory part is used as the search directory.
+    /// Returns an array of relative paths (relative to baseDir) that match.
+    /// Returns nil if the pattern escapes the sandbox.
+    public static func resolveGlob(baseDir: String, pattern: String) -> [String]? {
+        let dirPart = (pattern as NSString).deletingLastPathComponent
+        let filePattern = (pattern as NSString).lastPathComponent
+
+        // Determine the search directory
+        let searchDir: String
+        if dirPart.isEmpty {
+            searchDir = ""
+        } else {
+            // Validate the directory part stays in sandbox
+            guard sandboxedPath(base: baseDir, relativePath: dirPart) != nil else {
+                return nil
+            }
+            searchDir = dirPart
+        }
+
+        let baseDirExpanded = baseDir.replacingOccurrences(of: "~", with: NSHomeDirectory())
+        let searchPath = searchDir.isEmpty ? baseDirExpanded : (baseDirExpanded as NSString).appendingPathComponent(searchDir)
+        let searchURL = URL(fileURLWithPath: searchPath)
+
+        let fileManager = Foundation.FileManager.default
+        guard let items = try? fileManager.contentsOfDirectory(at: searchURL, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles]) else {
+            return []
+        }
+
+        var matches: [String] = []
+        for item in items {
+            let name = item.lastPathComponent
+            if globMatch(pattern: filePattern, filename: name) {
+                let relativePath = searchDir.isEmpty ? name : (searchDir as NSString).appendingPathComponent(name)
+                // Validate each match stays in sandbox
+                if sandboxedPath(base: baseDir, relativePath: relativePath) != nil {
+                    matches.append(relativePath)
+                }
+            }
+        }
+        return matches
     }
 }

--- a/Sources/ClawsyShared/NetworkManager.swift
+++ b/Sources/ClawsyShared/NetworkManager.swift
@@ -1411,7 +1411,7 @@ public class NetworkManager: NSObject, ObservableObject, WebSocketDelegate, UNUs
                 "client": ["id": connectClientId, "version": SharedConfig.versionDisplay, "platform": Self.connectPlatform, "mode": Self.connectClientMode],
                 "role": Self.connectRole, "caps": ["clipboard", "screen", "camera", "file", "location"],
                 "scopes": Self.connectScopes,
-                "commands": ["clipboard.read", "clipboard.write", "screen.capture", "camera.list", "camera.snap", "file.list", "file.get", "file.set", "file.get.chunk", "file.set.chunk", "file.delete", "file.rename", "file.move", "file.mkdir", "file.rmdir", "location.get", "location.start", "location.stop", "location.add_smart"],
+                "commands": ["clipboard.read", "clipboard.write", "screen.capture", "camera.list", "camera.snap", "file.list", "file.get", "file.set", "file.get.chunk", "file.set.chunk", "file.delete", "file.rename", "file.move", "file.copy", "file.mkdir", "file.rmdir", "file.stat", "file.exists", "file.batch", "location.get", "location.start", "location.stop", "location.add_smart"],
                 "permissions": ["clipboard.read": true, "clipboard.write": true],
                 "auth": ["token": authToken],
                 "device": [
@@ -1613,12 +1613,28 @@ public class NetworkManager: NSObject, ObservableObject, WebSocketDelegate, UNUs
             }
         case "file.delete", "file.rmdir":
             guard let name = params["name"] as? String else { sendError(id: id, code: -32602, message: "Missing 'name' parameter"); return }
-            let fullPath = (baseDir as NSString).appendingPathComponent(name)
             self.sendAck(id: id)
             let executeDelete = {
                 self.notifyAction(title: NSLocalizedString("NOTIFICATION_TITLE", bundle: .clawsy, comment: ""), body: "Deleted: \(name)", isAuto: ({ if let exp = self.filePermissionExpiry { return exp > Date() } else { return false } }()))
                 DispatchQueue.global(qos: .userInitiated).async {
-                    if ClawsyFileManager.deleteFile(at: fullPath) { self.sendResponse(id: id, result: ["status": "ok", "name": name]) } else { self.sendError(id: id, code: -32000, message: "Failed to delete file") }
+                    // Glob pattern support
+                    if ClawsyFileManager.isGlobPattern(name) {
+                        guard let matches = ClawsyFileManager.resolveGlob(baseDir: baseDir, pattern: name) else {
+                            self.sendError(id: id, code: -32003, message: "Path must stay within the shared folder"); return
+                        }
+                        var successCount = 0
+                        var errors: [[String: Any]] = []
+                        for match in matches {
+                            if let fullPath = ClawsyFileManager.sandboxedPath(base: baseDir, relativePath: match) {
+                                if ClawsyFileManager.deleteFile(at: fullPath) { successCount += 1 }
+                                else { errors.append(["file": match, "error": "Delete failed"]) }
+                            } else { errors.append(["file": match, "error": "Path traversal"]) }
+                        }
+                        self.sendResponse(id: id, result: ["status": "ok", "matched": matches.count, "success": successCount, "errors": errors])
+                    } else {
+                        let fullPath = (baseDir as NSString).appendingPathComponent(name)
+                        if ClawsyFileManager.deleteFile(at: fullPath) { self.sendResponse(id: id, result: ["status": "ok", "name": name]) } else { self.sendError(id: id, code: -32000, message: "Failed to delete file") }
+                    }
                 }
             }
             if let expiry = filePermissionExpiry, expiry > Date() { executeDelete() } else { onFileSyncRequested?(name, "Delete", { duration in if let duration = duration { self.filePermissionExpiry = Date().addingTimeInterval(duration) }; executeDelete() }, { self.sendError(id: id, code: -1, message: "User denied file delete") }) }
@@ -1638,10 +1654,94 @@ public class NetworkManager: NSObject, ObservableObject, WebSocketDelegate, UNUs
             let executeMove = {
                 self.notifyAction(title: NSLocalizedString("NOTIFICATION_TITLE", bundle: .clawsy, comment: ""), body: "Moved: \(source) → \(destination)", isAuto: ({ if let exp = self.filePermissionExpiry { return exp > Date() } else { return false } }()))
                 DispatchQueue.global(qos: .userInitiated).async {
-                    let result = ClawsyFileManager.moveFile(baseDir: baseDir, source: source, destination: destination)
+                    // Glob pattern support
+                    if ClawsyFileManager.isGlobPattern(source) {
+                        guard let matches = ClawsyFileManager.resolveGlob(baseDir: baseDir, pattern: source) else {
+                            self.sendError(id: id, code: -32003, message: "Path must stay within the shared folder"); return
+                        }
+                        var successCount = 0
+                        var errors: [[String: Any]] = []
+                        for match in matches {
+                            let destPath = (destination as NSString).appendingPathComponent((match as NSString).lastPathComponent)
+                            let result = ClawsyFileManager.moveFile(baseDir: baseDir, source: match, destination: destPath)
+                            switch result {
+                            case .success: successCount += 1
+                            case .failure(let err): errors.append(["file": match, "error": err.description])
+                            }
+                        }
+                        self.sendResponse(id: id, result: ["status": "ok", "matched": matches.count, "success": successCount, "errors": errors])
+                    } else {
+                        let result = ClawsyFileManager.moveFile(baseDir: baseDir, source: source, destination: destination)
+                        switch result {
+                        case .success:
+                            self.sendResponse(id: id, result: ["status": "ok", "source": source, "destination": destination])
+                        case .failure(let error):
+                            let code: Int
+                            switch error {
+                            case .sourceNotFound: code = -32001
+                            case .destinationExists: code = -32002
+                            case .pathTraversal: code = -32003
+                            case .moveFailed: code = -32000
+                            }
+                            self.sendError(id: id, code: code, message: error.description)
+                        }
+                    }
+                }
+            }
+            if let expiry = filePermissionExpiry, expiry > Date() { executeMove() } else { onFileSyncRequested?(source, "Move to \(destination)", { duration in if let duration = duration { self.filePermissionExpiry = Date().addingTimeInterval(duration) }; executeMove() }, { self.sendError(id: id, code: -1, message: "User denied file move") }) }
+        case "file.copy":
+            guard let source = params["source"] as? String, let destination = params["destination"] as? String else {
+                sendError(id: id, code: -32602, message: "Missing 'source' or 'destination' parameter"); return
+            }
+            self.sendAck(id: id)
+            let executeCopy = {
+                self.notifyAction(title: NSLocalizedString("NOTIFICATION_TITLE", bundle: .clawsy, comment: ""), body: "Copied: \(source) → \(destination)", isAuto: ({ if let exp = self.filePermissionExpiry { return exp > Date() } else { return false } }()))
+                DispatchQueue.global(qos: .userInitiated).async {
+                    if ClawsyFileManager.isGlobPattern(source) {
+                        guard let matches = ClawsyFileManager.resolveGlob(baseDir: baseDir, pattern: source) else {
+                            self.sendError(id: id, code: -32003, message: "Path must stay within the shared folder"); return
+                        }
+                        var successCount = 0
+                        var errors: [[String: Any]] = []
+                        for match in matches {
+                            let destPath = (destination as NSString).appendingPathComponent((match as NSString).lastPathComponent)
+                            let result = ClawsyFileManager.copyFile(baseDir: baseDir, source: match, destination: destPath)
+                            switch result {
+                            case .success: successCount += 1
+                            case .failure(let err): errors.append(["file": match, "error": err.description])
+                            }
+                        }
+                        self.sendResponse(id: id, result: ["status": "ok", "matched": matches.count, "success": successCount, "errors": errors])
+                    } else {
+                        let result = ClawsyFileManager.copyFile(baseDir: baseDir, source: source, destination: destination)
+                        switch result {
+                        case .success:
+                            self.sendResponse(id: id, result: ["status": "ok", "source": source, "destination": destination])
+                        case .failure(let error):
+                            let code: Int
+                            switch error {
+                            case .sourceNotFound: code = -32001
+                            case .destinationExists: code = -32002
+                            case .pathTraversal: code = -32003
+                            case .moveFailed: code = -32000
+                            }
+                            self.sendError(id: id, code: code, message: error.description)
+                        }
+                    }
+                }
+            }
+            if let expiry = filePermissionExpiry, expiry > Date() { executeCopy() } else { onFileSyncRequested?(source, "Copy to \(destination)", { duration in if let duration = duration { self.filePermissionExpiry = Date().addingTimeInterval(duration) }; executeCopy() }, { self.sendError(id: id, code: -1, message: "User denied file copy") }) }
+        case "file.rename":
+            let path = params["path"] as? String ?? params["name"] as? String
+            guard let path = path, let newName = params["newName"] as? String else { sendError(id: id, code: -32602, message: "Missing 'path' or 'newName' parameter"); return }
+            self.sendAck(id: id)
+            let executeRename = {
+                self.notifyAction(title: NSLocalizedString("NOTIFICATION_TITLE", bundle: .clawsy, comment: ""), body: "Renamed: \(path) → \(newName)", isAuto: ({ if let exp = self.filePermissionExpiry { return exp > Date() } else { return false } }()))
+                DispatchQueue.global(qos: .userInitiated).async {
+                    let result = ClawsyFileManager.renameFile(baseDir: baseDir, path: path, newName: newName)
                     switch result {
                     case .success:
-                        self.sendResponse(id: id, result: ["status": "ok", "source": source, "destination": destination])
+                        self.sendResponse(id: id, result: ["status": "ok", "path": path, "newName": newName])
                     case .failure(let error):
                         let code: Int
                         switch error {
@@ -1654,18 +1754,136 @@ public class NetworkManager: NSObject, ObservableObject, WebSocketDelegate, UNUs
                     }
                 }
             }
-            if let expiry = filePermissionExpiry, expiry > Date() { executeMove() } else { onFileSyncRequested?(source, "Move to \(destination)", { duration in if let duration = duration { self.filePermissionExpiry = Date().addingTimeInterval(duration) }; executeMove() }, { self.sendError(id: id, code: -1, message: "User denied file move") }) }
-        case "file.rename":
-            guard let name = params["name"] as? String, let newName = params["newName"] as? String else { sendError(id: id, code: -32602, message: "Missing 'name' or 'newName' parameter"); return }
-            let fullPath = (baseDir as NSString).appendingPathComponent(name)
+            if let expiry = filePermissionExpiry, expiry > Date() { executeRename() } else { onFileSyncRequested?(path, "Rename to \(newName)", { duration in if let duration = duration { self.filePermissionExpiry = Date().addingTimeInterval(duration) }; executeRename() }, { self.sendError(id: id, code: -1, message: "User denied file rename") }) }
+        case "file.stat":
+            let path = params["path"] as? String ?? ""
+            guard !path.isEmpty else { sendError(id: id, code: -32602, message: "Missing 'path' parameter"); return }
             self.sendAck(id: id)
-            let executeRename = {
-                self.notifyAction(title: NSLocalizedString("NOTIFICATION_TITLE", bundle: .clawsy, comment: ""), body: "Renamed: \(name) -> \(newName)", isAuto: ({ if let exp = self.filePermissionExpiry { return exp > Date() } else { return false } }()))
+            DispatchQueue.global(qos: .userInitiated).async {
+                let stat = ClawsyFileManager.statFile(baseDir: baseDir, relativePath: path)
+                self.sendResponse(id: id, result: stat)
+            }
+        case "file.exists":
+            let path = params["path"] as? String ?? ""
+            guard !path.isEmpty else { sendError(id: id, code: -32602, message: "Missing 'path' parameter"); return }
+            self.sendAck(id: id)
+            DispatchQueue.global(qos: .userInitiated).async {
+                let result = ClawsyFileManager.existsFile(baseDir: baseDir, relativePath: path)
+                self.sendResponse(id: id, result: result)
+            }
+        case "file.batch":
+            guard let ops = params["ops"] as? [[String: Any]] else {
+                sendError(id: id, code: -32602, message: "Missing 'ops' parameter"); return
+            }
+            self.sendAck(id: id)
+            let executeBatch = {
                 DispatchQueue.global(qos: .userInitiated).async {
-                    if ClawsyFileManager.renameFile(at: fullPath, to: newName) { self.sendResponse(id: id, result: ["status": "ok", "name": newName]) } else { self.sendError(id: id, code: -32000, message: "Failed to rename file") }
+                    var results: [[String: Any]] = []
+                    for (index, op) in ops.enumerated() {
+                        guard let opType = op["op"] as? String else {
+                            results.append(["index": index, "op": "unknown", "success": false, "error": "Missing 'op' field"])
+                            continue
+                        }
+                        switch opType {
+                        case "move":
+                            guard let src = op["src"] as? String, let dst = op["dst"] as? String else {
+                                results.append(["index": index, "op": opType, "success": false, "error": "Missing src/dst"]); continue
+                            }
+                            if ClawsyFileManager.isGlobPattern(src) {
+                                guard let matches = ClawsyFileManager.resolveGlob(baseDir: baseDir, pattern: src) else {
+                                    results.append(["index": index, "op": opType, "success": false, "error": "Path traversal"]); continue
+                                }
+                                var successCount = 0; var errors: [[String: Any]] = []
+                                for match in matches {
+                                    let destPath = (dst as NSString).appendingPathComponent((match as NSString).lastPathComponent)
+                                    switch ClawsyFileManager.moveFile(baseDir: baseDir, source: match, destination: destPath) {
+                                    case .success: successCount += 1
+                                    case .failure(let e): errors.append(["file": match, "error": e.description])
+                                    }
+                                }
+                                results.append(["index": index, "op": opType, "success": errors.isEmpty, "matched": matches.count, "successCount": successCount, "errors": errors])
+                            } else {
+                                switch ClawsyFileManager.moveFile(baseDir: baseDir, source: src, destination: dst) {
+                                case .success: results.append(["index": index, "op": opType, "success": true])
+                                case .failure(let e): results.append(["index": index, "op": opType, "success": false, "error": e.description])
+                                }
+                            }
+                        case "copy":
+                            guard let src = op["src"] as? String, let dst = op["dst"] as? String else {
+                                results.append(["index": index, "op": opType, "success": false, "error": "Missing src/dst"]); continue
+                            }
+                            if ClawsyFileManager.isGlobPattern(src) {
+                                guard let matches = ClawsyFileManager.resolveGlob(baseDir: baseDir, pattern: src) else {
+                                    results.append(["index": index, "op": opType, "success": false, "error": "Path traversal"]); continue
+                                }
+                                var successCount = 0; var errors: [[String: Any]] = []
+                                for match in matches {
+                                    let destPath = (dst as NSString).appendingPathComponent((match as NSString).lastPathComponent)
+                                    switch ClawsyFileManager.copyFile(baseDir: baseDir, source: match, destination: destPath) {
+                                    case .success: successCount += 1
+                                    case .failure(let e): errors.append(["file": match, "error": e.description])
+                                    }
+                                }
+                                results.append(["index": index, "op": opType, "success": errors.isEmpty, "matched": matches.count, "successCount": successCount, "errors": errors])
+                            } else {
+                                switch ClawsyFileManager.copyFile(baseDir: baseDir, source: src, destination: dst) {
+                                case .success: results.append(["index": index, "op": opType, "success": true])
+                                case .failure(let e): results.append(["index": index, "op": opType, "success": false, "error": e.description])
+                                }
+                            }
+                        case "delete":
+                            guard let src = op["src"] as? String else {
+                                results.append(["index": index, "op": opType, "success": false, "error": "Missing src"]); continue
+                            }
+                            if ClawsyFileManager.isGlobPattern(src) {
+                                guard let matches = ClawsyFileManager.resolveGlob(baseDir: baseDir, pattern: src) else {
+                                    results.append(["index": index, "op": opType, "success": false, "error": "Path traversal"]); continue
+                                }
+                                var successCount = 0; var errors: [[String: Any]] = []
+                                for match in matches {
+                                    if let fullPath = ClawsyFileManager.sandboxedPath(base: baseDir, relativePath: match) {
+                                        if ClawsyFileManager.deleteFile(at: fullPath) { successCount += 1 }
+                                        else { errors.append(["file": match, "error": "Delete failed"]) }
+                                    } else { errors.append(["file": match, "error": "Path traversal"]) }
+                                }
+                                results.append(["index": index, "op": opType, "success": errors.isEmpty, "matched": matches.count, "successCount": successCount, "errors": errors])
+                            } else {
+                                if let fullPath = ClawsyFileManager.sandboxedPath(base: baseDir, relativePath: src) {
+                                    results.append(["index": index, "op": opType, "success": ClawsyFileManager.deleteFile(at: fullPath)])
+                                } else { results.append(["index": index, "op": opType, "success": false, "error": "Path traversal"]) }
+                            }
+                        case "mkdir":
+                            guard let dst = op["dst"] as? String else {
+                                results.append(["index": index, "op": opType, "success": false, "error": "Missing dst"]); continue
+                            }
+                            if let fullPath = ClawsyFileManager.sandboxedPath(base: baseDir, relativePath: dst) {
+                                results.append(["index": index, "op": opType, "success": ClawsyFileManager.createDirectory(at: fullPath)])
+                            } else { results.append(["index": index, "op": opType, "success": false, "error": "Path traversal"]) }
+                        case "rename":
+                            guard let path = op["path"] as? String, let newName = op["newName"] as? String else {
+                                results.append(["index": index, "op": opType, "success": false, "error": "Missing path/newName"]); continue
+                            }
+                            switch ClawsyFileManager.renameFile(baseDir: baseDir, path: path, newName: newName) {
+                            case .success: results.append(["index": index, "op": opType, "success": true])
+                            case .failure(let e): results.append(["index": index, "op": opType, "success": false, "error": e.description])
+                            }
+                        case "stat":
+                            guard let path = op["path"] as? String else {
+                                results.append(["index": index, "op": opType, "success": false, "error": "Missing path"]); continue
+                            }
+                            var stat = ClawsyFileManager.statFile(baseDir: baseDir, relativePath: path)
+                            stat["index"] = index
+                            stat["op"] = opType
+                            stat["success"] = stat["exists"] as? Bool ?? false
+                            results.append(stat)
+                        default:
+                            results.append(["index": index, "op": opType, "success": false, "error": "Unknown operation: \(opType)"])
+                        }
+                    }
+                    self.sendResponse(id: id, result: ["status": "ok", "results": results])
                 }
             }
-            if let expiry = filePermissionExpiry, expiry > Date() { executeRename() } else { onFileSyncRequested?(name, "Rename to \(newName)", { duration in if let duration = duration { self.filePermissionExpiry = Date().addingTimeInterval(duration) }; executeRename() }, { self.sendError(id: id, code: -1, message: "User denied file rename") }) }
+            if let expiry = filePermissionExpiry, expiry > Date() { executeBatch() } else { onFileSyncRequested?("batch (\(ops.count) ops)", "Batch file operations", { duration in if let duration = duration { self.filePermissionExpiry = Date().addingTimeInterval(duration) }; executeBatch() }, { self.sendError(id: id, code: -1, message: "User denied batch operations") }) }
         default: sendError(id: id, code: -32601, message: "Method not found")
         }
     }

--- a/Sources/ClawsyShared/Resources/de.lproj/Localizable.strings
+++ b/Sources/ClawsyShared/Resources/de.lproj/Localizable.strings
@@ -11,6 +11,8 @@
 "NOTIFICATION_TITLE" = "Clawsy Dateisync";
 "NOTIFICATION_BODY_DOWNLOADING" = "Lade herunter: %@";
 "NOTIFICATION_BODY_UPLOADING" = "Lade hoch: %@";
+"NOTIFICATION_BODY_COPYING" = "Kopiere: %@";
+"NOTIFICATION_BODY_BATCH" = "Batch-Operation: %@ Ops";
 "REVOKE_PERMISSION" = "Zugriff widerrufen";
 "CLIPBOARD_SYNC" = "Zwischenablage-Sync";
 "CHAR_COUNT %lld" = "%lld Zeichen";

--- a/Sources/ClawsyShared/Resources/en.lproj/Localizable.strings
+++ b/Sources/ClawsyShared/Resources/en.lproj/Localizable.strings
@@ -11,6 +11,8 @@
 "NOTIFICATION_TITLE" = "Clawsy File Sync";
 "NOTIFICATION_BODY_DOWNLOADING" = "Downloading: %@";
 "NOTIFICATION_BODY_UPLOADING" = "Uploading: %@";
+"NOTIFICATION_BODY_COPYING" = "Copying: %@";
+"NOTIFICATION_BODY_BATCH" = "Batch operation: %@ ops";
 "REVOKE_PERMISSION" = "Revoke Permissions";
 "CLIPBOARD_SYNC" = "Clipboard Sync";
 "CHAR_COUNT %lld" = "%lld characters";

--- a/Sources/ClawsyShared/Resources/es.lproj/Localizable.strings
+++ b/Sources/ClawsyShared/Resources/es.lproj/Localizable.strings
@@ -11,6 +11,8 @@
 "NOTIFICATION_TITLE" = "Clawsy Sincronización";
 "NOTIFICATION_BODY_DOWNLOADING" = "Descargando: %@";
 "NOTIFICATION_BODY_UPLOADING" = "Subiendo: %@";
+"NOTIFICATION_BODY_COPYING" = "Copiando: %@";
+"NOTIFICATION_BODY_BATCH" = "Operación por lotes: %@ ops";
 "REVOKE_PERMISSION" = "Revocar acceso";
 "CLIPBOARD_SYNC" = "Sincronización de portapapeles";
 "CHAR_COUNT %lld" = "%lld caracteres";

--- a/Sources/ClawsyShared/Resources/fr.lproj/Localizable.strings
+++ b/Sources/ClawsyShared/Resources/fr.lproj/Localizable.strings
@@ -11,6 +11,8 @@
 "NOTIFICATION_TITLE" = "Clawsy Synchro";
 "NOTIFICATION_BODY_DOWNLOADING" = "Téléchargement : %@";
 "NOTIFICATION_BODY_UPLOADING" = "Envoi : %@";
+"NOTIFICATION_BODY_COPYING" = "Copie : %@";
+"NOTIFICATION_BODY_BATCH" = "Opération par lot : %@ ops";
 "REVOKE_PERMISSION" = "Révoquer l'accès";
 "CLIPBOARD_SYNC" = "Synchro Presse-papiers";
 "CHAR_COUNT %lld" = "%lld caractères";


### PR DESCRIPTION
## File-API v2 Komplett-Ausbau

### New Commands
- **file.copy** — Copy files/dirs with full sandboxing (supports glob patterns)
- **file.stat** — Get file metadata: size, modified, created, isDirectory
- **file.exists** — Quick existence check
- **file.batch** — Execute multiple file ops in a single call (move, copy, delete, mkdir, rename, stat)
- **file.rename** — Upgraded: now uses sandboxed path validation, accepts both `path` and `name` param

### Glob Pattern Support
- `file.move`, `file.copy`, `file.delete` now support `*` and `?` wildcards
- Implemented in pure Swift via `NSPredicate LIKE` — no shell involved
- All matched paths validated against sandbox
- Bulk response format: `{ matched, success, errors }`
- For move/copy with globs: destination must be a directory

### file.batch
Supports ops: `move`, `copy`, `delete`, `mkdir`, `rename`, `stat`
Each op returns individual result. Full sandboxing on every path in every op.

### Hello Handshake
Registered: `file.copy`, `file.stat`, `file.exists`, `file.batch`

### L10N
Added `NOTIFICATION_BODY_COPYING` and `NOTIFICATION_BODY_BATCH` in all 4 locales (en, de, fr, es).

### allowCommands Documentation (Issue #4)
Added documentation to SKILL.md for gateway `allowCommands` sync:
- Gateway config is NOT modified automatically (security rule)
- Check/suggest flow documented for agents
- Full command list provided for manual configuration

Closes #4, closes #5