### PR TITLE
docs: rewrite agent handbook with correct API params

### DIFF
--- a/for-agents.md
+++ b/for-agents.md
@@ -8,7 +8,7 @@ Clawsy is a native macOS menu bar app (v0.9.33) that gives you direct access to 
 
 - **Screenshots** — capture the full screen or a selected area
 - **Clipboard** — read/write clipboard content
-- **Quick Send** — your human pushes text to you via `⌘⇧K`
+- **Quick Send** — your human pushes text to you via a global hotkey
 - **Camera** — take a photo from the Mac's camera (with human confirmation)
 - **Shared Folder** — read and write files your human can access in Finder
 - **Mission Control** — show your human what you're working on with live progress bars
@@ -32,6 +32,21 @@ If your human uses macOS and doesn't have Clawsy:
 
 ---
 
+## Common Mistakes
+
+Before you start — these are the most frequent errors agents make:
+
+| Mistake | Correct |
+|---|---|
+| `file.list` with `{"path": "."}` | `file.list` with **no params** (root) or `{"subPath": "folder/"}` |
+| `file.set` with plain text content | `file.set` content is **always Base64-encoded** |
+| `file.get` with `{"path": "..."}` | `file.get` uses `{"name": "filename.txt"}` |
+| `file.exists` with `{"name": "..."}` | `file.exists` uses `{"path": "filename.txt"}` |
+| `file.rename` moving to a new directory | `file.rename` changes name only (same dir); use `file.move` for paths |
+| Writing `.agent_status.json` to shared folder | Obsolete since v0.5.6 — use `agent.status` via `sessions_send` |
+
+---
+
 ## Setup: What to Do Once Clawsy Is Installed
 
 ### 1. Send agent.info (every heartbeat + session start)
@@ -40,12 +55,12 @@ This shows your name and model in the Clawsy header. TTL is 45 minutes — resen
 
 ```python
 sessions_send(sessionKey="clawsy-service", timeoutSeconds=3,
-  message='{"kind":"agent.info","payload":{"agentName":"YourAgentName","model":"claude-sonnet-4-6","updatedAt":"2026-03-04T09:00:00Z"}}')
+  message='{"kind":"agent.info","payload":{"agentName":"<AGENT_NAME>","model":"<YOUR_MODEL>","updatedAt":"<ISO-UTC>"}}')
 ```
 
 **Fields:**
-- `agentName`: Your display name (e.g., "CyberClaw")
-- `model`: Your current LLM model
+- `agentName`: Your display name
+- `model`: Your current LLM model identifier
 - `updatedAt`: ISO 8601 UTC timestamp
 
 ### 2. Send agent.status (during active work)
@@ -54,7 +69,7 @@ This shows live task progress in Mission Control.
 
 ```python
 sessions_send(sessionKey="clawsy-service", timeoutSeconds=3,
-  message='{"kind":"agent.status","payload":{"agentName":"YourAgentName","title":"Building feature X","progress":0.5,"statusText":"Running tests..."}}')
+  message='{"kind":"agent.status","payload":{"agentName":"<AGENT_NAME>","title":"Building feature X","progress":0.5,"statusText":"Running tests..."}}')
 ```
 
 **Fields:**
@@ -64,13 +79,10 @@ sessions_send(sessionKey="clawsy-service", timeoutSeconds=3,
 
 **Timeout errors are normal.** The event is delivered when Clawsy is connected. Don't retry.
 
-> ⚠️ **WebSocket-only since v0.5.6.** Do NOT write `.agent_status.json` to the shared folder — that method is obsolete.
-
 ### 3. Add to HEARTBEAT.md
 
 ```markdown
 ## Clawsy (every heartbeat)
-Send agent.info to clawsy-service:
 sessions_send(sessionKey="clawsy-service", timeoutSeconds=3,
   message='{"kind":"agent.info","payload":{"agentName":"<NAME>","model":"<MODEL>","updatedAt":"<ISO-UTC>"}}')
 
@@ -86,10 +98,9 @@ https://github.com/iret77/clawsy
 When spawning subagents, add this block so they report progress:
 
 ```
-## Clawsy Mission Control
-Report progress after each significant step:
+## Clawsy Mission Control (MANDATORY)
 sessions_send(sessionKey="clawsy-service", timeoutSeconds=3,
-  message='{"kind":"agent.status","payload":{"agentName":"<label>","title":"<step>","progress":<0.0-1.0>,"statusText":"<details>"}}')
+  message='{"kind":"agent.status","payload":{"agentName":"<label>","title":"<task>","progress":<0.0-1.0>,"statusText":"<details>"}}')
 Start=0.05 | Mid=0.5 | Done=1.0
 ```
 
@@ -105,9 +116,124 @@ Look for `clawsy_envelope` messages:
 - `type: "screenshot"` — screen capture with image data
 - `type: "clipboard"` — clipboard text
 - `type: "camera"` — camera photo with image data
-- `type: "quick_send"` — user message via `⌘⇧K`, includes telemetry
+- `type: "quick_send"` — user message via global hotkey, includes telemetry
 
-### 6. Invoke Node Commands
+---
+
+## File API Reference
+
+All file operations use the `nodes` tool and are sandboxed to the shared folder (default: `~/Documents/Clawsy`). Path traversal attempts are rejected with error code `-32003`.
+
+### Listing Files
+
+```python
+# Root directory — NO parameters
+nodes(action="invoke", invokeCommand="file.list")
+
+# Subdirectory — use "subPath" (NOT "path")
+nodes(action="invoke", invokeCommand="file.list",
+      invokeParamsJson='{"subPath": "reports/"}')
+
+# Recursive — all files, all subfolders (max depth 5)
+nodes(action="invoke", invokeCommand="file.list",
+      invokeParamsJson='{"recursive": true}')
+
+# Both combined
+nodes(action="invoke", invokeCommand="file.list",
+      invokeParamsJson='{"subPath": "docs/", "recursive": true}')
+```
+
+### Reading Files
+
+```python
+# Parameter: "name" (NOT "path")
+nodes(action="invoke", invokeCommand="file.get",
+      invokeParamsJson='{"name": "report.pdf"}')
+
+# Subfolder file
+nodes(action="invoke", invokeCommand="file.get",
+      invokeParamsJson='{"name": "reports/quarterly.pdf"}')
+```
+
+### Writing Files
+
+```python
+# Content MUST be base64-encoded — always
+nodes(action="invoke", invokeCommand="file.set",
+      invokeParamsJson='{"name": "output.txt", "content": "SGVsbG8gV29ybGQ="}')
+```
+
+### Checking & Inspecting
+
+```python
+# Check existence — parameter: "path"
+nodes(action="invoke", invokeCommand="file.exists",
+      invokeParamsJson='{"path": "report.pdf"}')
+# → Returns: {"exists": true} or {"exists": false}
+
+# Get metadata (size, dates, type) — parameter: "path", supports glob
+nodes(action="invoke", invokeCommand="file.stat",
+      invokeParamsJson='{"path": "report.pdf"}')
+
+# Glob example
+nodes(action="invoke", invokeCommand="file.stat",
+      invokeParamsJson='{"path": "*.pdf"}')
+```
+
+### Creating Directories
+
+```python
+# Creates intermediate directories automatically
+nodes(action="invoke", invokeCommand="file.mkdir",
+      invokeParamsJson='{"name": "folder/subfolder"}')
+```
+
+### Deleting
+
+```python
+# Delete a file
+nodes(action="invoke", invokeCommand="file.delete",
+      invokeParamsJson='{"name": "old-file.txt"}')
+
+# Remove a directory (including non-empty)
+nodes(action="invoke", invokeCommand="file.rmdir",
+      invokeParamsJson='{"name": "old-folder"}')
+```
+
+### Moving & Copying
+
+```python
+# Move — supports glob patterns in source
+nodes(action="invoke", invokeCommand="file.move",
+      invokeParamsJson='{"source": "old/path.txt", "destination": "new/path.txt"}')
+
+# Copy — supports glob patterns in source
+nodes(action="invoke", invokeCommand="file.copy",
+      invokeParamsJson='{"source": "original.txt", "destination": "backup.txt"}')
+
+# Rename — name change only, same directory
+nodes(action="invoke", invokeCommand="file.rename",
+      invokeParamsJson='{"path": "old-name.txt", "newName": "new-name.txt"}')
+```
+
+### Batch Operations
+
+```python
+nodes(action="invoke", invokeCommand="file.batch",
+      invokeParamsJson='{"ops": [{"op": "copy", "source": "a.txt", "destination": "b.txt"}, {"op": "move", "source": "c.txt", "destination": "d.txt"}]}')
+```
+
+### Large Files (> 200 KB)
+
+Use `file.get.chunk` / `file.set.chunk` for reliable chunked transfers. The `nodes` tool has payload limits — chunking splits large files into smaller pieces and reassembles them on the other side.
+
+A helper script `tools/clawsy_file_transfer.py` may be available in the workspace to automate this.
+
+**Glob patterns:** `file.move`, `file.copy`, `file.delete`, and `file.stat` support glob patterns (`*.txt`, `docs/*.pdf`) in the source/path parameter.
+
+---
+
+## Other Node Commands
 
 ```python
 # Find the Clawsy node
@@ -117,54 +243,37 @@ nodes(action="status")
 # Screenshot
 nodes(action="invoke", invokeCommand="screen.capture")
 
-# Clipboard
+# Clipboard read
 nodes(action="invoke", invokeCommand="clipboard.read")
-nodes(action="invoke", invokeCommand="clipboard.write",
-      invokeParamsJson='{"text": "Text for clipboard"}')
 
-# Camera
+# Clipboard write
+nodes(action="invoke", invokeCommand="clipboard.write",
+      invokeParamsJson='{"text": "Hello from agent"}')
+
+# Camera list
+nodes(action="invoke", invokeCommand="camera.list")
+
+# Camera snap
 nodes(action="invoke", invokeCommand="camera.snap",
       invokeParamsJson='{"facing": "front"}')
 
-# Files (shared folder, default ~/Documents/Clawsy)
-nodes(action="invoke", invokeCommand="file.list",
-      invokeParamsJson='{"path": "."}')
-nodes(action="invoke", invokeCommand="file.get",
-      invokeParamsJson='{"name": "report.pdf"}')
-nodes(action="invoke", invokeCommand="file.set",
-      invokeParamsJson='{"name": "output.txt", "content": "<base64>"}')
-nodes(action="invoke", invokeCommand="file.move",
-      invokeParamsJson='{"source": "old/file.txt", "destination": "new/file.txt"}')
-nodes(action="invoke", invokeCommand="file.copy",
-      invokeParamsJson='{"source": "original.txt", "destination": "backup.txt"}')
-nodes(action="invoke", invokeCommand="file.rename",
-      invokeParamsJson='{"path": "old-name.txt", "newName": "new-name.txt"}')
-nodes(action="invoke", invokeCommand="file.stat",
-      invokeParamsJson='{"path": "report.pdf"}')
-nodes(action="invoke", invokeCommand="file.exists",
-      invokeParamsJson='{"path": "report.pdf"}')
-nodes(action="invoke", invokeCommand="file.mkdir",
-      invokeParamsJson='{"name": "new-folder/subfolder"}')
-nodes(action="invoke", invokeCommand="file.delete",
-      invokeParamsJson='{"name": "old-file.txt"}')
-# Batch operations
-nodes(action="invoke", invokeCommand="file.batch",
-      invokeParamsJson='{"ops": [{"op": "copy", "source": "a.txt", "destination": "b.txt"}, {"op": "move", "source": "c.txt", "destination": "d.txt"}]}')
+# Location
+nodes(action="invoke", invokeCommand="location.get")
 ```
 
-Available commands: `screen.capture`, `clipboard.read`, `clipboard.write`, `camera.list`, `camera.snap`, `file.list`, `file.get`, `file.set`, `file.get.chunk`, `file.set.chunk`, `file.move`, `file.copy`, `file.rename`, `file.stat`, `file.exists`, `file.batch`, `file.delete`, `file.rmdir`, `file.mkdir`, `location.get`
+All available commands: `screen.capture`, `clipboard.read`, `clipboard.write`, `camera.list`, `camera.snap`, `file.list`, `file.get`, `file.set`, `file.get.chunk`, `file.set.chunk`, `file.move`, `file.copy`, `file.rename`, `file.stat`, `file.exists`, `file.batch`, `file.delete`, `file.rmdir`, `file.mkdir`, `location.get`
 
 **Glob patterns:** `file.move`, `file.copy`, `file.delete`, and `file.stat` support glob patterns (`*.txt`, `docs/*.pdf`) in the source/path parameter. Results include matched file count.
 
 **Path sandboxing:** All file operations are sandboxed to the shared folder. Path traversal attempts (e.g., `../../etc/passwd`) are rejected with error code `-32003`.
 
-> Most commands that access user data require user approval on the Mac side. Note: clipboard.read currently has a known issue where it does not show an approval dialog (see #18).
+> Most commands that access user data require user approval on the Mac side. The user sees a permission dialog and can allow once, allow for 1 hour, or deny.
 
 ---
 
 ## Quick Send Envelope
 
-When the user sends a message via `⌘⇧K`:
+When the user sends a message via the global hotkey:
 
 ```json
 {
@@ -172,7 +281,7 @@ When the user sends a message via `⌘⇧K`:
     "type": "quick_send",
     "content": "The user's message",
     "version": "0.9.33",
-    "localTime": "2026-03-04T10:30:00Z",
+    "localTime": "2026-03-14T10:30:00Z",
     "tz": "Europe/Berlin",
     "telemetry": {
       "deviceName": "MacBook Pro",
@@ -198,8 +307,6 @@ When the user sends a message via `⌘⇧K`:
 ## Multi-Host
 
 Clawsy can connect to multiple OpenClaw gateways simultaneously. Each host has its own connection, device token, and isolated shared folder. From your perspective as an agent, nothing changes — you interact with Clawsy the same way.
-
-If your human runs multiple OpenClaw instances, they can connect Clawsy to all of them at once.
 
 ---
 

--- a/server/templates/CLAWSY.md
+++ b/server/templates/CLAWSY.md
@@ -1,118 +1,187 @@
-# CLAWSY.md — Clawsy Mac Companion Integration Guide
+# CLAWSY.md — Clawsy Integration (v0.9.33)
 
-Clawsy is the macOS companion app for OpenClaw. It gives your agent direct access to the user's Mac — screenshots, camera, clipboard, files, and more.
+Clawsy is a macOS companion app for OpenClaw. It gives your agent access to the user's Mac: screenshots, clipboard, camera, files, and live task progress.
 
-**Repo:** [iret77/clawsy](https://github.com/iret77/clawsy) (GitHub, public)
+## Common Mistakes
 
----
-
-## WICHTIG: Wo deine Daten ankommen
-
-QuickSend, Clipboard, Screenshots und Kamera-Bilder landen **NICHT** im Haupt-Chat.
-Sie landen in der `clawsy-service` Session.
-
-**Abrufen:**
-```python
-sessions_history(sessionKey="clawsy-service", limit=5)
-```
-
-**Oder:** `clawsy-context.json` im Workspace-Root lesen (strukturiertes JSON mit allen Events).
-
-**Prüfe diese Quellen bei JEDER User-Anfrage die Clipboard, Screenshot oder Kamera betrifft.**
-
----
-
-## Capabilities
-
-| Capability | When to Use |
+| Mistake | Correct |
 |---|---|
-| **Screenshot** | When the user asks what's on screen, debug UI issues, visual feedback |
-| **Camera** | When user wants to show something, environment context |
-| **Clipboard Read** | When user says "check what I copied" or wants to share text |
-| **Clipboard Write** | Push code/text directly to their clipboard — very useful! |
-| **Quick Send** | Text sent directly to the agent (user types, you receive) |
-| **Files** | Read/write files in the configured shared folder |
-| **FinderSync** | Right-click folders → "Clawsy >" submenu → rules/telemetry/actions |
-
-**Rule:** If Clawsy is connected and it improves UX — use it. Don't ask for permission first.
+| `file.list` with `{"path": "."}` | `file.list` with **no params** (root) or `{"subPath": "folder/"}` |
+| `file.set` with plain text content | `file.set` content is **always Base64-encoded** |
+| `file.get` with `{"path": "..."}` | `file.get` uses `{"name": "filename.txt"}` |
+| `file.exists` with `{"name": "..."}` | `file.exists` uses `{"path": "filename.txt"}` |
+| `file.rename` moving to a new dir | `file.rename` changes name only (same dir); use `file.move` for paths |
+| Writing `.agent_status.json` to shared folder | Obsolete since v0.5.6 — use `agent.status` via `sessions_send` |
 
 ---
 
-## Commands (nodes tool)
+## File API Reference
 
-Clawsy registers as a `node`. Use the `nodes` tool:
+All file operations are sandboxed to the shared folder (default: `~/Documents/Clawsy`). Path traversal is rejected.
+
+### List Files
 
 ```python
-nodes(action="invoke", invokeCommand="screen.capture")
-nodes(action="invoke", invokeCommand="clipboard.read")
-nodes(action="invoke", invokeCommand="clipboard.write", invokeParamsJson='{"text":"..."}')
-nodes(action="invoke", invokeCommand="camera.snap", invokeParamsJson='{"facing":"front"}')
-nodes(action="invoke", invokeCommand="camera.list")
-nodes(action="invoke", invokeCommand="file.list", invokeParamsJson='{"path": "."}')
-nodes(action="invoke", invokeCommand="file.get", invokeParamsJson='{"name":"report.pdf"}')
-nodes(action="invoke", invokeCommand="file.set", invokeParamsJson='{"name":"notes.txt", "content":"<base64>"}')
-nodes(action="invoke", invokeCommand="location.get")
+# Root directory (NO parameters)
+nodes(action="invoke", invokeCommand="file.list")
+
+# Subdirectory
+nodes(action="invoke", invokeCommand="file.list",
+      invokeParamsJson='{"subPath": "reports/"}')
+
+# Recursive (all files, max depth 5)
+nodes(action="invoke", invokeCommand="file.list",
+      invokeParamsJson='{"recursive": true}')
 ```
 
-Available commands: `screen.capture`, `clipboard.read`, `clipboard.write`, `camera.list`, `camera.snap`, `file.list`, `file.get`, `file.set`, `location.get`
+### Read / Write Files
+
+```python
+# Read a file (returns base64-encoded content)
+nodes(action="invoke", invokeCommand="file.get",
+      invokeParamsJson='{"name": "report.pdf"}')
+
+# Write a file (content MUST be base64-encoded)
+nodes(action="invoke", invokeCommand="file.set",
+      invokeParamsJson='{"name": "output.txt", "content": "<base64-encoded>"}')
+```
+
+### Check / Inspect Files
+
+```python
+# Check if file exists → {"exists": true/false}
+nodes(action="invoke", invokeCommand="file.exists",
+      invokeParamsJson='{"path": "report.pdf"}')
+
+# Get metadata (size, dates, type; supports glob)
+nodes(action="invoke", invokeCommand="file.stat",
+      invokeParamsJson='{"path": "report.pdf"}')
+```
+
+### Create / Delete
+
+```python
+# Create directory (creates intermediate dirs)
+nodes(action="invoke", invokeCommand="file.mkdir",
+      invokeParamsJson='{"name": "folder/subfolder"}')
+
+# Delete file or directory
+nodes(action="invoke", invokeCommand="file.delete",
+      invokeParamsJson='{"name": "old-file.txt"}')
+
+# Remove directory (including non-empty)
+nodes(action="invoke", invokeCommand="file.rmdir",
+      invokeParamsJson='{"name": "old-folder"}')
+```
+
+### Move / Copy / Rename
+
+```python
+# Move (supports glob in source)
+nodes(action="invoke", invokeCommand="file.move",
+      invokeParamsJson='{"source": "old/path.txt", "destination": "new/path.txt"}')
+
+# Copy (supports glob in source)
+nodes(action="invoke", invokeCommand="file.copy",
+      invokeParamsJson='{"source": "original.txt", "destination": "backup.txt"}')
+
+# Rename (name only, same directory)
+nodes(action="invoke", invokeCommand="file.rename",
+      invokeParamsJson='{"path": "old-name.txt", "newName": "new-name.txt"}')
+```
+
+### Batch Operations
+
+```python
+nodes(action="invoke", invokeCommand="file.batch",
+      invokeParamsJson='{"ops": [{"op": "copy", "source": "a.txt", "destination": "b.txt"}, {"op": "move", "source": "c.txt", "destination": "d.txt"}]}')
+```
+
+### Large Files (> 200 KB)
+
+Use `file.get.chunk` / `file.set.chunk` for reliable chunked transfers. See SKILL.md for details.
+
+---
+
+## Mission Control Protocol
+
+Clawsy displays agent status in its Mission Control UI via WebSocket events.
+
+### agent.info — Header Identity (send on session start + every heartbeat, TTL: 45 min)
+
+```python
+sessions_send(sessionKey="clawsy-service", timeoutSeconds=3,
+  message='{"kind":"agent.info","payload":{"agentName":"<AGENT_NAME>","model":"<YOUR_MODEL>","updatedAt":"<ISO-UTC>"}}')
+```
+
+### agent.status — Task Progress (send during active work)
+
+```python
+sessions_send(sessionKey="clawsy-service", timeoutSeconds=3,
+  message='{"kind":"agent.status","payload":{"agentName":"<AGENT_NAME>","title":"Building feature X","progress":0.5,"statusText":"Running tests..."}}')
+```
+
+- `progress`: Float `0.0`-`1.0`. At `1.0`, task auto-removes after 10 seconds.
+- **Timeout errors are normal.** The event is delivered when Clawsy is connected. Do not retry.
+
+### Subagent Snippet
+
+Include this in every subagent task prompt:
+
+```
+## Clawsy Mission Control (MANDATORY)
+sessions_send(sessionKey="clawsy-service", timeoutSeconds=3,
+  message='{"kind":"agent.status","payload":{"agentName":"<label>","title":"<task>","progress":<0.0-1.0>,"statusText":"<details>"}}')
+Start=0.05 | Mid=0.5 | Done=1.0
+```
+
+---
+
+## Other Capabilities
+
+| Command | Usage |
+|---|---|
+| `screen.capture` | `nodes(action="invoke", invokeCommand="screen.capture")` |
+| `clipboard.read` | `nodes(action="invoke", invokeCommand="clipboard.read")` |
+| `clipboard.write` | `nodes(action="invoke", invokeCommand="clipboard.write", invokeParamsJson='{"text": "..."}')` |
+| `camera.list` | `nodes(action="invoke", invokeCommand="camera.list")` |
+| `camera.snap` | `nodes(action="invoke", invokeCommand="camera.snap", invokeParamsJson='{"facing": "front"}')` |
+| `location.get` | `nodes(action="invoke", invokeCommand="location.get")` |
+
+Most commands require user approval on the Mac side (allow once / allow 1 hour / deny).
 
 ---
 
 ## clawsy-service Session
 
-Screenshots, camera photos, and other automatic Clawsy events land in the dedicated `clawsy-service` session — **not in the main chat**. This keeps the main chat clean.
+Screenshots, clipboard events, camera photos, and Quick Send messages arrive in the `clawsy-service` session — not in the main chat.
 
-### Why?
-Without a separate channel, every screenshot would interrupt the main chat. With `clawsy-service`, all push events collect there and the agent can retrieve them on demand.
-
-### How to Retrieve
 ```python
-sessions_history(sessionKey="clawsy-service", limit=5)
+sessions_history(sessionKey="clawsy-service", limit=10)
 ```
 
-### How It Works (Technical)
-The app sends screenshots via `node.event` with `event: "agent.deeplink"` and `sessionKey: "clawsy-service"` in payloadJSON. The Gateway routes it to this session instead of the active chat.
+Look for `clawsy_envelope` messages with `type`: `"screenshot"`, `"clipboard"`, `"camera"`, `"quick_send"`.
 
 ---
 
-## clawsy-context.json
+## Quick Send Envelope Format
 
-The `clawsy-monitor` service (see `server/monitor.mjs`) watches the `clawsy-service` session JSONL and extracts events into a structured JSON file in your workspace:
-
-```json
-{
-  "clipboard": { "text": "...", "ts": 1234567890, "receivedAt": "..." },
-  "screenshots": [{ "filePath": "clawsy-cache/screenshot-123.jpg", "ts": ..., "receivedAt": "..." }],
-  "shares": [{ "text": "...", "ts": ..., "receivedAt": "..." }],
-  "quickSend": [{ "text": "...", "ts": ..., "receivedAt": "..." }],
-  "updatedAt": "..."
-}
-```
-
-Each bucket is a ring buffer (max 20 items, 24h TTL). Screenshots are saved as files in the `clawsy-cache/` directory.
-
----
-
-## Envelope Format
-
-Incoming messages from Clawsy are wrapped in `clawsy_envelope`:
+When the user sends a message via the global hotkey:
 
 ```json
 {
   "clawsy_envelope": {
     "type": "quick_send",
-    "content": "The actual message",
-    "version": "0.9.12",
-    "localTime": "2026-02-27T01:09:22.609Z",
+    "content": "The user's message",
+    "version": "0.9.33",
+    "localTime": "2026-03-14T10:30:00Z",
     "tz": "Europe/Berlin",
     "telemetry": {
-      "deviceName": "<device-name>",
-      "deviceModel": "Mac",
-      "batteryLevel": 0.51,
-      "isCharging": false,
+      "deviceName": "MacBook Pro",
+      "batteryLevel": 0.75,
+      "isCharging": true,
       "thermalState": 0,
-      "activeApp": "Clawsy",
-      "appSwitchRate": 0.22,
+      "activeApp": "Safari",
       "moodScore": 70,
       "isUnusualHour": false
     }
@@ -120,117 +189,28 @@ Incoming messages from Clawsy are wrapped in `clawsy_envelope`:
 }
 ```
 
-### Telemetry Hints
-- `thermalState > 1` → Mac is running hot, avoid heavy tasks
-- `batteryLevel < 0.2` → mention battery if relevant
-- `moodScore < 40` → user is stressed/busy, keep it short
-- `isUnusualHour: true` → unusual time, be considerate
+**Telemetry hints:** `thermalState > 1` = overheating | `batteryLevel < 0.2` = low battery | `moodScore < 40` = user stressed | `isUnusualHour` = odd hours
 
 ---
 
-## Mission Control Protocol
-
-Clawsy displays agent status in its Mission Control view via WebSocket events.
-
-> **Mandatory for every agent:** Send `agent.info` at session start AND every heartbeat (TTL: 45 min). Send `agent.status` during active work and close with `progress: 1.0`.
-
-### agent.info — Show Model in Popover Header
-
-```python
-sessions_send(sessionKey="clawsy-service", timeoutSeconds=3, message=json.dumps({
-    "kind": "agent.info",
-    "payload": {
-        "agentName": "<YOUR_AGENT_NAME>",
-        "model": "<CURRENT_MODEL>",
-        "updatedAt": "<ISO-UTC>"
-    }
-}))
-```
-
-### agent.status — Show Tasks in Mission Control
-
-```python
-sessions_send(sessionKey="clawsy-service", timeoutSeconds=3, message=json.dumps({
-    "kind": "agent.status",
-    "payload": {
-        "agentName": "<YOUR_AGENT_NAME>",
-        "title": "Building feature X",
-        "progress": 0.6,
-        "statusText": "Compiling sources…"
-    }
-}))
-```
-
-### Behavior
-- Clawsy receives events live over the existing WS connection
-- `progress >= 1.0` → task disappears after 10 seconds
-- On disconnect → all tasks are automatically cleared
-- No file I/O, no FileWatcher, no stale data issues
-- Timeout on `sessions_send` is normal and expected — the event is delivered if Clawsy is connected
-
-### 🤖 Mandatory Snippet for Every Subagent You Spawn
-
-When you delegate work to a subagent, paste this block into **every** task prompt. Replace `<label>` with the actual subagent label/name.
-
-```
-## Mission Control Updates (MANDATORY)
-
-Report progress after each significant step using sessions_send:
-
-Step 1 — immediately after starting:
-sessions_send(sessionKey="agent:main:clawsy-service", timeoutSeconds=3,
-  message='{"kind":"agent.status","payload":{"agentName":"<label>","title":"<task title>","progress":0.05,"statusText":"Starting…"}}')
-
-Step 2 — at roughly 50% progress:
-sessions_send(sessionKey="agent:main:clawsy-service", timeoutSeconds=3,
-  message='{"kind":"agent.status","payload":{"agentName":"<label>","title":"<task title>","progress":0.5,"statusText":"<what you are doing>"}}')
-
-Final step — after commit/done:
-sessions_send(sessionKey="agent:main:clawsy-service", timeoutSeconds=3,
-  message='{"kind":"agent.status","payload":{"agentName":"<label>","title":"<task title>","progress":1.0,"statusText":"Done"}}')
-
-Use the FULL session key: agent:main:clawsy-service (not just "clawsy-service").
-Timeout is expected and normal — the event still delivers.
-```
-
----
-
-## Finding the Connected Node
+## Finding the Clawsy Node
 
 ```python
 nodes(action="status")
-# → List of all connected nodes; pick the one with platform="macos" and connected=true
-# → Note the nodeId for all subsequent calls
-```
-
-Find the shared folder path:
-```python
-nodes(action="invoke", node="<nodeId>", invokeCommand="file.list",
-      invokeParamsJson='{"path": "."}')
-# Clawsy configures the shared folder in app settings (default: ~/Documents/Clawsy)
+# Look for platform="macos", connected=true
 ```
 
 ---
 
-## After Install — Pairing Link
+## Setup & Pairing
 
-After running `install.sh`, the pairing link is saved to a file in your workspace. Check for it and forward it to your human:
+For first-time setup, pairing, and install scripts, see the full SKILL.md:
+`~/.openclaw/workspace/skills/clawsy-server/SKILL.md`
 
-```bash
-cat ~/.openclaw/workspace/clawsy-pairing-link.txt 2>/dev/null
-```
+**HEARTBEAT.md snippet:**
 
-If the file exists, send the link to your human — they click it on their Mac to connect Clawsy:
-
-> Here is your Clawsy pairing link — click it on your Mac:
-> `clawsy://pair?code=<CODE>`
->
-> 1. Click the link → macOS asks "Open with Clawsy?" → Yes
-> 2. Clawsy connects automatically
-> 3. The auto-approve watcher approves the pairing — no further action needed!
-
-After successful pairing, delete the file:
-
-```bash
-rm -f ~/.openclaw/workspace/clawsy-pairing-link.txt
+```markdown
+## Clawsy (every heartbeat)
+sessions_send(sessionKey="clawsy-service", timeoutSeconds=3,
+  message='{"kind":"agent.info","payload":{"agentName":"<NAME>","model":"<MODEL>","updatedAt":"<ISO-UTC>"}}')
 ```


### PR DESCRIPTION
Rewrites `server/templates/CLAWSY.md` and `for-agents.md` with correct, neutral, LLM-agnostic documentation.

**Problem:** Agents on other instances kept failing file operations because the docs had wrong parameter names (`path` instead of `subPath` for `file.list`, missing Base64 requirement for `file.set`, etc.).

**Changes:**
- `server/templates/CLAWSY.md` — complete rewrite (216 lines). Common Mistakes table at the top, full File API reference with copy-paste-ready examples, Mission Control protocol, all capabilities.
- `for-agents.md` — same corrections, more detailed (311 lines).

**Design principle:** An agent reading only CLAWSY.md must immediately use the correct API — no trial-and-error.

All content is neutral (no personal names, no model-specific references, English, LLM-agnostic).