### PR TITLE
feat: Agent-Switcher — Route events to selectable agent

### DIFF
--- a/Sources/ClawsyMac/ClawsyApp.swift
+++ b/Sources/ClawsyMac/ClawsyApp.swift
@@ -435,7 +435,7 @@ Details in CLAWSY.md.
                 includeTelemetry: network.extendedContextEnabled) {
             network.sendEvent(kind: "agent.request", payload: [
                 "message": jsonString,
-                "sessionKey": "clawsy-service",
+                "sessionKey": network.targetSessionKey,
                 "deliver": false
             ])
             self.showStatusHUD(icon: "doc.on.clipboard.fill", title: "CLIPBOARD_SENT")
@@ -529,8 +529,8 @@ Details in CLAWSY.md.
                         type: "quick_send",
                         content: text,
                         includeTelemetry: network.extendedContextEnabled) {
-                        // Full envelope → clawsy-service (context storage)
-                        network.sendDeeplink(message: jsonString, sessionKey: "clawsy-service")
+                        // Full envelope → target session (context storage)
+                        network.sendDeeplink(message: jsonString, sessionKey: network.targetSessionKey)
                         // Trigger → main session (agent responds, quoting the message)
                         let trigger: [String: Any] = ["clawsy_envelope": [
                             "type": "quick_send_trigger",

--- a/Sources/ClawsyMac/ContentView.swift
+++ b/Sources/ClawsyMac/ContentView.swift
@@ -151,6 +151,11 @@ struct ContentView: View {
                 .padding(.bottom, 6)
             }
 
+            // --- Agent Picker ---
+            if !hostManager.profiles.isEmpty, hostManager.isConnected {
+                agentPickerSection
+            }
+
             // --- Main Actions List ---
             // Order: Quick Send (most active) → Screenshot → Clipboard → Camera (most deliberate)
             if !hostManager.profiles.isEmpty { VStack(spacing: 2) {
@@ -544,6 +549,78 @@ struct ContentView: View {
                 appDelegate.showStatusHUD(icon: "camera.fill", title: "PHOTO_SENT")
             }
         }
+    }
+
+    /// Compact agent picker — lets user choose which session receives events.
+    @ViewBuilder
+    private var agentPickerSection: some View {
+        let sessions = availableAgentSessions
+        HStack(spacing: 6) {
+            Image(systemName: "person.crop.circle")
+                .font(.system(size: 11))
+                .foregroundColor(.secondary)
+            Text(l10n: "AGENT_PICKER_LABEL")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(.secondary)
+            Spacer()
+            Picker("", selection: agentPickerBinding) {
+                Text(NSLocalizedString("AGENT_PICKER_DEFAULT", bundle: .clawsy, comment: ""))
+                    .tag("clawsy-service")
+                ForEach(sessions, id: \.id) { session in
+                    Text(agentDisplayName(for: session))
+                        .tag(session.id)
+                }
+            }
+            .pickerStyle(.menu)
+            .frame(maxWidth: 160)
+            .labelsHidden()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 6)
+    }
+
+    /// Sessions eligible for the agent picker: direct, running, not clawsy-service or main.
+    private var availableAgentSessions: [GatewaySession] {
+        guard let nm = network else { return [] }
+        return nm.gatewaySessions.filter { session in
+            session.kind == "direct" &&
+            session.status == "running" &&
+            session.id != "clawsy-service" &&
+            !session.id.hasSuffix(":main")
+        }
+    }
+
+    /// Binding that syncs Picker selection with NetworkManager.targetSessionKey,
+    /// falling back to "clawsy-service" when the chosen session disappears.
+    private var agentPickerBinding: Binding<String> {
+        Binding<String>(
+            get: {
+                guard let nm = network else { return "clawsy-service" }
+                let current = nm.targetSessionKey
+                // Validate: must be clawsy-service or still in available list
+                if current == "clawsy-service" { return current }
+                let valid = nm.gatewaySessions.contains { $0.id == current && $0.status == "running" }
+                if !valid {
+                    DispatchQueue.main.async { nm.targetSessionKey = "clawsy-service" }
+                    return "clawsy-service"
+                }
+                return current
+            },
+            set: { newValue in
+                network?.targetSessionKey = newValue
+            }
+        )
+    }
+
+    /// Display name for a session in the picker.
+    private func agentDisplayName(for session: GatewaySession) -> String {
+        if let label = session.label, !label.isEmpty {
+            return label
+        }
+        // Derive from key: "agent:main:slack:..." → "main"
+        let parts = session.id.split(separator: ":")
+        if parts.count >= 2 { return String(parts[1]) }
+        return session.id
     }
 
         func handleManualClipboardSend() {

--- a/Sources/ClawsyMac/Resources/de.lproj/Localizable.strings
+++ b/Sources/ClawsyMac/Resources/de.lproj/Localizable.strings
@@ -332,3 +332,7 @@
 
 // SSH Auto-Reconnect
 "STATUS_SSH_RECONNECTING" = "SSH-Tunnel wird wiederhergestellt…";
+
+// Agent Picker
+"AGENT_PICKER_LABEL" = "Aktiver Agent";
+"AGENT_PICKER_DEFAULT" = "Standard (clawsy-service)";

--- a/Sources/ClawsyMac/Resources/en.lproj/Localizable.strings
+++ b/Sources/ClawsyMac/Resources/en.lproj/Localizable.strings
@@ -331,3 +331,7 @@
 
 // SSH Auto-Reconnect
 "STATUS_SSH_RECONNECTING" = "Reconnecting SSH Tunnel…";
+
+// Agent Picker
+"AGENT_PICKER_LABEL" = "Active Agent";
+"AGENT_PICKER_DEFAULT" = "Default (clawsy-service)";

--- a/Sources/ClawsyMac/Resources/es.lproj/Localizable.strings
+++ b/Sources/ClawsyMac/Resources/es.lproj/Localizable.strings
@@ -330,3 +330,7 @@
 
 // SSH Auto-Reconnect
 "STATUS_SSH_RECONNECTING" = "Reconectando túnel SSH…";
+
+// Agent Picker
+"AGENT_PICKER_LABEL" = "Agente activo";
+"AGENT_PICKER_DEFAULT" = "Por defecto (clawsy-service)";

--- a/Sources/ClawsyMac/Resources/fr.lproj/Localizable.strings
+++ b/Sources/ClawsyMac/Resources/fr.lproj/Localizable.strings
@@ -330,3 +330,7 @@
 
 // SSH Auto-Reconnect
 "STATUS_SSH_RECONNECTING" = "Reconnexion du tunnel SSH…";
+
+// Agent Picker
+"AGENT_PICKER_LABEL" = "Agent actif";
+"AGENT_PICKER_DEFAULT" = "Par défaut (clawsy-service)";

--- a/Sources/ClawsyShared/NetworkManager.swift
+++ b/Sources/ClawsyShared/NetworkManager.swift
@@ -63,6 +63,15 @@ public class NetworkManager: NSObject, ObservableObject, WebSocketDelegate, UNUs
     @Published public var retryCountdown: Int = 0  // Seconds until next retry (0 = no retry pending)
     @Published public var serverDetected: Bool = false
     @Published public var serverSetupNeeded: Bool = false
+    
+    /// The session key that all events (QuickSend, Clipboard, Screenshot, Camera, Share) are routed to.
+    /// Persisted in SharedConfig.sharedDefaults so the Share Extension can read it too.
+    @Published public var targetSessionKey: String = "clawsy-service" {
+        didSet {
+            SharedConfig.sharedDefaults.set(targetSessionKey, forKey: "targetSessionKey")
+            SharedConfig.sharedDefaults.synchronize()
+        }
+    }
     private var retryTimer: Timer?
     private var retryAttempt: Int = 0
     private let baseRetryDelay: TimeInterval = 2.0
@@ -184,6 +193,7 @@ public class NetworkManager: NSObject, ObservableObject, WebSocketDelegate, UNUs
     public init(hostProfile: HostProfile) {
         self.hostProfile = hostProfile
         super.init()
+        loadPersistedTargetSession()
         loadOrGenerateSigningKey()
         setupNotifications()
         setupLocation()
@@ -192,9 +202,17 @@ public class NetworkManager: NSObject, ObservableObject, WebSocketDelegate, UNUs
     /// Legacy init (single-host mode, reads from SharedConfig)
     public override init() {
         super.init()
+        loadPersistedTargetSession()
         loadOrGenerateSigningKey()
         setupNotifications()
         setupLocation()
+    }
+    
+    /// Loads the persisted target session key from SharedConfig.sharedDefaults.
+    private func loadPersistedTargetSession() {
+        if let saved = SharedConfig.sharedDefaults.string(forKey: "targetSessionKey"), !saved.isEmpty {
+            targetSessionKey = saved
+        }
     }
     
     /// Returns the UserDefaults key for this host's signing key.
@@ -953,7 +971,7 @@ public class NetworkManager: NSObject, ObservableObject, WebSocketDelegate, UNUs
     public func sendOneShot(message: String, completion: @escaping (Bool) -> Void) {
         let send = { [weak self] in
             guard let self = self else { return }
-            self.sendDeeplink(message: message, sessionKey: "clawsy-service")
+            self.sendDeeplink(message: message, sessionKey: self.targetSessionKey)
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 completion(true)
                 self.disconnect()
@@ -1113,7 +1131,7 @@ public class NetworkManager: NSObject, ObservableObject, WebSocketDelegate, UNUs
 
         let body: [String: Any] = [
             "tool": "sessions_history",
-            "args": ["sessionKey": "clawsy-service", "limit": 20]
+            "args": ["sessionKey": targetSessionKey, "limit": 20]
         ]
         req.httpBody = try? JSONSerialization.data(withJSONObject: body)
 
@@ -2100,9 +2118,9 @@ public class NetworkManager: NSObject, ObservableObject, WebSocketDelegate, UNUs
     public func sendScreenshot(base64: String, mimeType: String = "image/jpeg") {
         let deviceName = Host.current().localizedName ?? "Mac"
 
-        // 1. Store in clawsy-service for agent context (silent)
+        // 1. Store in target session for agent context (silent)
         let storagePayload: [String: Any] = [
-            "sessionKey": "clawsy-service",
+            "sessionKey": targetSessionKey,
             "message": "📸 Screenshot von \(deviceName)",
             "deliver": false,
             "receipt": false,
@@ -2176,16 +2194,16 @@ public class NetworkManager: NSObject, ObservableObject, WebSocketDelegate, UNUs
         send(json: frame)
     }
 
-    /// Send a message to clawsy-service session (silent, no Telegram delivery).
+    /// Send a message to the target session (silent, no Telegram delivery).
     public func sendServiceEvent(message: String, payload: [String: Any] = [:]) {
-        sendDeeplink(message: message, sessionKey: "clawsy-service", deliver: false)
+        sendDeeplink(message: message, sessionKey: targetSessionKey, deliver: false)
     }
 
-    /// Send a camera photo: stores in clawsy-service (context) AND triggers main chat delivery.
+    /// Send a camera photo: stores in target session (context) AND triggers main chat delivery.
     public func sendPhoto(base64: String, deviceName: String = "Kamera") {
-        // 1. Store in clawsy-service for agent context (silent)
+        // 1. Store in target session for agent context (silent)
         let storagePayload: [String: Any] = [
-            "sessionKey": "clawsy-service",
+            "sessionKey": targetSessionKey,
             "message": "📷 Kamerafoto von \(Host.current().localizedName ?? "Mac") (\(deviceName))",
             "deliver": false,
             "receipt": false,

--- a/Sources/ClawsyShared/Resources/de.lproj/Localizable.strings
+++ b/Sources/ClawsyShared/Resources/de.lproj/Localizable.strings
@@ -340,3 +340,7 @@
 
 // SSH Auto-Reconnect
 "STATUS_SSH_RECONNECTING" = "SSH-Tunnel wird wiederhergestellt…";
+
+// Agent Picker
+"AGENT_PICKER_LABEL" = "Aktiver Agent";
+"AGENT_PICKER_DEFAULT" = "Standard (clawsy-service)";

--- a/Sources/ClawsyShared/Resources/en.lproj/Localizable.strings
+++ b/Sources/ClawsyShared/Resources/en.lproj/Localizable.strings
@@ -339,3 +339,7 @@
 
 // SSH Auto-Reconnect
 "STATUS_SSH_RECONNECTING" = "Reconnecting SSH Tunnel…";
+
+// Agent Picker
+"AGENT_PICKER_LABEL" = "Active Agent";
+"AGENT_PICKER_DEFAULT" = "Default (clawsy-service)";

--- a/Sources/ClawsyShared/Resources/es.lproj/Localizable.strings
+++ b/Sources/ClawsyShared/Resources/es.lproj/Localizable.strings
@@ -292,3 +292,7 @@
 
 // SSH Auto-Reconnect
 "STATUS_SSH_RECONNECTING" = "Reconectando túnel SSH…";
+
+// Agent Picker
+"AGENT_PICKER_LABEL" = "Agente activo";
+"AGENT_PICKER_DEFAULT" = "Por defecto (clawsy-service)";

--- a/Sources/ClawsyShared/Resources/fr.lproj/Localizable.strings
+++ b/Sources/ClawsyShared/Resources/fr.lproj/Localizable.strings
@@ -292,3 +292,7 @@
 
 // SSH Auto-Reconnect
 "STATUS_SSH_RECONNECTING" = "Reconnexion du tunnel SSH…";
+
+// Agent Picker
+"AGENT_PICKER_LABEL" = "Agent actif";
+"AGENT_PICKER_DEFAULT" = "Par défaut (clawsy-service)";

--- a/Sources/ClawsyShared/SharedConfig.swift
+++ b/Sources/ClawsyShared/SharedConfig.swift
@@ -59,6 +59,12 @@ public struct SharedConfig {
     
     public static var extendedContextEnabled: Bool { sharedDefaults.bool(forKey: "extendedContextEnabled") }
     
+    /// The session key that events are routed to (persisted for Share Extension access).
+    public static var targetSessionKey: String {
+        get { sharedDefaults.string(forKey: "targetSessionKey") ?? "clawsy-service" }
+        set { sharedDefaults.set(newValue, forKey: "targetSessionKey"); sharedDefaults.synchronize() }
+    }
+    
     public static var quickSendHotkey: String { sharedDefaults.string(forKey: "quickSendHotkey") ?? "K" }
     public static var pushClipboardHotkey: String { sharedDefaults.string(forKey: "pushClipboardHotkey") ?? "V" }
     public static var cameraHotkey: String { sharedDefaults.string(forKey: "cameraHotkey") ?? "P" }


### PR DESCRIPTION
## Agent-Switcher (#31)

**Problem:** All events (QuickSend, Clipboard, Screenshots, Camera, Share) were hardcoded to `clawsy-service`. Users with multiple agents couldn't choose which agent receives events.

### Changes

**NetworkManager.swift:**
- New `targetSessionKey` published property (default: `clawsy-service`)
- Persisted in `SharedConfig.sharedDefaults` (accessible from Share Extension)
- Loaded on init from persisted value
- All `"clawsy-service"` hardcodes replaced with `targetSessionKey`:
  - `sendOneShot`, `sendServiceEvent`, `sendPhoto`, `sendScreenshot`, `pollAgentState`

**ClawsyApp.swift:**
- Global clipboard push + QuickSend routing use `network.targetSessionKey`

**ContentView.swift:**
- Agent Picker UI (compact `Picker` with menu style)
- Filters to `kind == "direct"` running sessions only
- Auto-fallback to `clawsy-service` when selected session disappears
- Placed between connection status and main actions

**SharedConfig.swift:**
- Static `targetSessionKey` property for Share Extension read access

**L10N:**
- `AGENT_PICKER_LABEL` + `AGENT_PICKER_DEFAULT` in all 4 locales (en/de/fr/es) x 2 bundles

### Exceptions (intentional)
- `MissionControlView.swift` filter: keeps `clawsy-service` hardcoded (hides service session from sub-agents list)

Closes #31