### PR TITLE
feat: improve large file transfer — bigger chunks, checksum, retry (#32)

### DIFF
--- a/Sources/ClawsyMac/Resources/de.lproj/Localizable.strings
+++ b/Sources/ClawsyMac/Resources/de.lproj/Localizable.strings
@@ -336,3 +336,4 @@
 // Agent Picker
 "AGENT_PICKER_LABEL" = "Aktiver Agent";
 "AGENT_PICKER_DEFAULT" = "Standard (clawsy-service)";
+"NOTIFICATION_BODY_CHECKSUM" = "Prüfsumme: %@";

--- a/Sources/ClawsyMac/Resources/en.lproj/Localizable.strings
+++ b/Sources/ClawsyMac/Resources/en.lproj/Localizable.strings
@@ -335,3 +335,4 @@
 // Agent Picker
 "AGENT_PICKER_LABEL" = "Active Agent";
 "AGENT_PICKER_DEFAULT" = "Default (clawsy-service)";
+"NOTIFICATION_BODY_CHECKSUM" = "Checksum: %@";

--- a/Sources/ClawsyMac/Resources/es.lproj/Localizable.strings
+++ b/Sources/ClawsyMac/Resources/es.lproj/Localizable.strings
@@ -334,3 +334,4 @@
 // Agent Picker
 "AGENT_PICKER_LABEL" = "Agente activo";
 "AGENT_PICKER_DEFAULT" = "Por defecto (clawsy-service)";
+"NOTIFICATION_BODY_CHECKSUM" = "Suma de verificación: %@";

--- a/Sources/ClawsyMac/Resources/fr.lproj/Localizable.strings
+++ b/Sources/ClawsyMac/Resources/fr.lproj/Localizable.strings
@@ -334,3 +334,4 @@
 // Agent Picker
 "AGENT_PICKER_LABEL" = "Agent actif";
 "AGENT_PICKER_DEFAULT" = "Par défaut (clawsy-service)";
+"NOTIFICATION_BODY_CHECKSUM" = "Somme de contrôle : %@";

--- a/Sources/ClawsyShared/NetworkManager.swift
+++ b/Sources/ClawsyShared/NetworkManager.swift
@@ -1511,7 +1511,7 @@ public class NetworkManager: NSObject, ObservableObject, WebSocketDelegate, UNUs
                 "client": ["id": connectClientId, "version": SharedConfig.versionDisplay, "platform": Self.connectPlatform, "mode": Self.connectClientMode],
                 "role": Self.connectRole, "caps": ["clipboard", "screen", "camera", "file", "location"],
                 "scopes": Self.connectScopes,
-                "commands": ["clipboard.read", "clipboard.write", "screen.capture", "camera.list", "camera.snap", "file.list", "file.get", "file.set", "file.get.chunk", "file.set.chunk", "file.delete", "file.rename", "file.move", "file.copy", "file.mkdir", "file.rmdir", "file.stat", "file.exists", "file.batch", "location.get", "location.start", "location.stop", "location.add_smart"],
+                "commands": ["clipboard.read", "clipboard.write", "screen.capture", "camera.list", "camera.snap", "file.list", "file.get", "file.set", "file.get.chunk", "file.set.chunk", "file.checksum", "file.delete", "file.rename", "file.move", "file.copy", "file.mkdir", "file.rmdir", "file.stat", "file.exists", "file.batch", "location.get", "location.start", "location.stop", "location.add_smart"],
                 "permissions": ["clipboard.read": true, "clipboard.write": true],
                 "auth": ["token": authToken],
                 "device": [
@@ -1683,7 +1683,9 @@ public class NetworkManager: NSObject, ObservableObject, WebSocketDelegate, UNUs
                         let assembledB64 = assembled.base64EncodedString()
                         switch ClawsyFileManager.writeFile(at: fullPathChunkSet, base64Content: assembledB64) {
                         case .success:
-                            self.sendResponse(id: id, result: ["status": "ok", "name": name, "assembled": true])
+                            let digest = SHA256.hash(data: assembled)
+                            let checksum = digest.map { String(format: "%02x", $0) }.joined()
+                            self.sendResponse(id: id, result: ["status": "ok", "name": name, "assembled": true, "checksum": checksum, "size": assembled.count])
                         case .failure:
                             self.sendError(id: id, code: -32000, message: "Failed to assemble file")
                         }
@@ -1705,7 +1707,7 @@ public class NetworkManager: NSObject, ObservableObject, WebSocketDelegate, UNUs
                   let chunkIndex = params["chunkIndex"] as? Int else {
                 sendError(id: id, code: -32602, message: "Missing parameters"); return
             }
-            let chunkSizeBytes = (params["chunkSizeBytes"] as? Int) ?? 262144
+            let chunkSizeBytes = (params["chunkSizeBytes"] as? Int) ?? 358400
             guard let fullPathChunkGet = ClawsyFileManager.sandboxedPath(base: baseDir, relativePath: name) else {
                 sendError(id: id, code: -32003, message: "Path must stay within the shared folder"); return
             }
@@ -1739,6 +1741,22 @@ public class NetworkManager: NSObject, ObservableObject, WebSocketDelegate, UNUs
                 executeGetChunk()
             } else {
                 onFileSyncRequested?(name, "Download (chunked)", { duration in if let d = duration { self.filePermissionExpiry = Date().addingTimeInterval(d) }; executeGetChunk() }, { self.sendError(id: id, code: -1, message: "User denied") })
+            }
+        case "file.checksum":
+            guard let name = params["name"] as? String else {
+                sendError(id: id, code: -32602, message: "Missing 'name' parameter"); return
+            }
+            guard let fullPathChecksum = ClawsyFileManager.sandboxedPath(base: baseDir, relativePath: name) else {
+                sendError(id: id, code: -32003, message: "Path must stay within the shared folder"); return
+            }
+            self.sendAck(id: id)
+            DispatchQueue.global(qos: .userInitiated).async {
+                guard let data = FileManager.default.contents(atPath: fullPathChecksum) else {
+                    self.sendError(id: id, code: -32000, message: "Failed to read file"); return
+                }
+                let digest = SHA256.hash(data: data)
+                let checksum = digest.map { String(format: "%02x", $0) }.joined()
+                self.sendResponse(id: id, result: ["checksum": checksum, "size": data.count, "name": name])
             }
         case "file.delete", "file.rmdir":
             guard let name = params["name"] as? String else { sendError(id: id, code: -32602, message: "Missing 'name' parameter"); return }

--- a/Sources/ClawsyShared/Resources/de.lproj/Localizable.strings
+++ b/Sources/ClawsyShared/Resources/de.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "NOTIFICATION_BODY_UPLOADING" = "Lade hoch: %@";
 "NOTIFICATION_BODY_COPYING" = "Kopiere: %@";
 "NOTIFICATION_BODY_BATCH" = "Batch-Operation: %@ Ops";
+"NOTIFICATION_BODY_CHECKSUM" = "Prüfsumme: %@";
 "REVOKE_PERMISSION" = "Zugriff widerrufen";
 "CLIPBOARD_SYNC" = "Zwischenablage-Sync";
 "CHAR_COUNT %lld" = "%lld Zeichen";

--- a/Sources/ClawsyShared/Resources/en.lproj/Localizable.strings
+++ b/Sources/ClawsyShared/Resources/en.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "NOTIFICATION_BODY_UPLOADING" = "Uploading: %@";
 "NOTIFICATION_BODY_COPYING" = "Copying: %@";
 "NOTIFICATION_BODY_BATCH" = "Batch operation: %@ ops";
+"NOTIFICATION_BODY_CHECKSUM" = "Checksum: %@";
 "REVOKE_PERMISSION" = "Revoke Permissions";
 "CLIPBOARD_SYNC" = "Clipboard Sync";
 "CHAR_COUNT %lld" = "%lld characters";

--- a/Sources/ClawsyShared/Resources/es.lproj/Localizable.strings
+++ b/Sources/ClawsyShared/Resources/es.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "NOTIFICATION_BODY_UPLOADING" = "Subiendo: %@";
 "NOTIFICATION_BODY_COPYING" = "Copiando: %@";
 "NOTIFICATION_BODY_BATCH" = "Operación por lotes: %@ ops";
+"NOTIFICATION_BODY_CHECKSUM" = "Suma de verificación: %@";
 "REVOKE_PERMISSION" = "Revocar acceso";
 "CLIPBOARD_SYNC" = "Sincronización de portapapeles";
 "CHAR_COUNT %lld" = "%lld caracteres";

--- a/Sources/ClawsyShared/Resources/fr.lproj/Localizable.strings
+++ b/Sources/ClawsyShared/Resources/fr.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "NOTIFICATION_BODY_UPLOADING" = "Envoi : %@";
 "NOTIFICATION_BODY_COPYING" = "Copie : %@";
 "NOTIFICATION_BODY_BATCH" = "Opération par lot : %@ ops";
+"NOTIFICATION_BODY_CHECKSUM" = "Somme de contrôle : %@";
 "REVOKE_PERMISSION" = "Révoquer l'accès";
 "CLIPBOARD_SYNC" = "Synchro Presse-papiers";
 "CHAR_COUNT %lld" = "%lld caractères";


### PR DESCRIPTION
## Changes

### App-Side (NetworkManager.swift)
- **Chunk size**: Default `chunkSizeBytes` increased from 256KB to 350KB (base64 ~467KB, safely under 512KB WS limit)
- **Assembly checksum**: `file.set.chunk` response now includes SHA256 `checksum` and `size` after final assembly
- **New command**: `file.checksum` — returns SHA256, size, and name for any file in the shared folder
- **Hello handshake**: `file.checksum` registered in commands list
- **L10N**: `NOTIFICATION_BODY_CHECKSUM` added to all 4 locales × 2 bundles (ClawsyMac + ClawsyShared)

### Agent-Side (tools/clawsy_file_transfer.py)
- **Chunk size**: 200KB → 350KB
- **Retry logic**: 3 attempts per chunk with exponential backoff (1s, 2s, 4s)
- **Checksum verification**: Post-upload/download SHA256 integrity check via `file.checksum`
- **Resume support**: `--resume` flag probes for existing temp chunks and continues from there
- **Better errors**: Reports which chunk failed, why, and retry count
- **`--no-verify` flag**: Opt out of checksum verification

### Not Changed
- WebSocket payload limit (512KB) — Gateway constraint, untouched
- `file.set`/`file.get` for small files — unchanged

Closes #32