### PR TITLE
fix: agent picker filter + agent name in permission dialogs

### DIFF
--- a/Sources/ClawsyMac/CameraPreviewView.swift
+++ b/Sources/ClawsyMac/CameraPreviewView.swift
@@ -3,8 +3,20 @@ import AVFoundation
 
 struct CameraPreviewView: View {
     let image: NSImage
+    let agentName: String?
     let onConfirm: () -> Void
     let onCancel: () -> Void
+
+    private var displayAgent: String {
+        agentName ?? NSLocalizedString("GENERIC_AGENT", bundle: .clawsy, comment: "")
+    }
+
+    private var remoteUserText: String {
+        if agentName != nil {
+            return String(format: NSLocalizedString("REMOTE_NAMED_USER_ASKING", bundle: .clawsy, comment: ""), displayAgent)
+        }
+        return NSLocalizedString("REMOTE_USER_ASKING", bundle: .clawsy, comment: "")
+    }
     
     var body: some View {
         VStack(spacing: 0) {
@@ -25,7 +37,7 @@ struct CameraPreviewView: View {
                     Text("CAMERA_PREVIEW_TITLE")
                         .font(.system(size: 15, weight: .bold))
                     
-                    Text("REMOTE_USER_ASKING")
+                    Text(remoteUserText)
                         .font(.system(size: 11, weight: .medium))
                         .foregroundColor(.secondary)
                 }

--- a/Sources/ClawsyMac/ClawsyApp.swift
+++ b/Sources/ClawsyMac/ClawsyApp.swift
@@ -583,29 +583,32 @@ Details in CLAWSY.md.
         }
     }
     
-    func showClipboardRequest(content: String, direction: ClipboardDirection = .write, onConfirm: @escaping () -> Void, onCancel: @escaping () -> Void) {
+    func showClipboardRequest(content: String, direction: ClipboardDirection = .write, agentName: String? = nil, onConfirm: @escaping () -> Void, onCancel: @escaping () -> Void) {
         let view = ClipboardPreviewWindow(
             content: content,
             direction: direction,
+            agentName: agentName,
             onConfirm: { onConfirm(); self.alertWindow?.close() },
             onCancel: { onCancel(); self.alertWindow?.close() }
         )
         showFloatingWindow(view: view, title: "Clipboard Sync", autosaveName: "ai.clawsy.ClipboardWindow")
     }
     
-    func showFileSyncRequest(filename: String, operation: String, onConfirm: @escaping (TimeInterval?) -> Void, onCancel: @escaping () -> Void) {
+    func showFileSyncRequest(filename: String, operation: String, agentName: String? = nil, onConfirm: @escaping (TimeInterval?) -> Void, onCancel: @escaping () -> Void) {
         let view = FileSyncRequestWindow(
             filename: filename,
             operation: operation,
+            agentName: agentName,
             onConfirm: { duration in onConfirm(duration); self.alertWindow?.close() },
             onCancel: { onCancel(); self.alertWindow?.close() }
         )
         showFloatingWindow(view: view, title: NSLocalizedString("FILESYNC_WINDOW_TITLE", bundle: .clawsy, comment: ""), autosaveName: "ai.clawsy.FileWindow")
     }
 
-    func showScreenshotRequest(requestedInteractive: Bool, onConfirm: @escaping (Bool) -> Void, onCancel: @escaping () -> Void) {
+    func showScreenshotRequest(requestedInteractive: Bool, agentName: String? = nil, onConfirm: @escaping (Bool) -> Void, onCancel: @escaping () -> Void) {
         let view = ScreenshotRequestWindow(
             requestedInteractive: requestedInteractive,
+            agentName: agentName,
             onConfirm: { interactive in
                 onConfirm(interactive)
                 self.alertWindow?.close()
@@ -618,9 +621,10 @@ Details in CLAWSY.md.
         showFloatingWindow(view: view, title: "Screenshot Request", autosaveName: "ai.clawsy.ScreenshotWindow")
     }
 
-    func showCameraPreview(image: NSImage, onConfirm: @escaping () -> Void, onCancel: @escaping () -> Void) {
+    func showCameraPreview(image: NSImage, agentName: String? = nil, onConfirm: @escaping () -> Void, onCancel: @escaping () -> Void) {
         let view = CameraPreviewView(
             image: image,
+            agentName: agentName,
             onConfirm: { onConfirm(); self.alertWindow?.close() },
             onCancel: { onCancel(); self.alertWindow?.close() }
         )

--- a/Sources/ClawsyMac/ClipboardPreviewWindow.swift
+++ b/Sources/ClawsyMac/ClipboardPreviewWindow.swift
@@ -9,6 +9,7 @@ enum ClipboardDirection {
 struct ClipboardPreviewWindow: View {
     let content: String
     let direction: ClipboardDirection
+    let agentName: String?
     let onConfirm: () -> Void
     let onCancel: () -> Void
     
@@ -16,6 +17,24 @@ struct ClipboardPreviewWindow: View {
         content.count
     }
     
+    private var displayAgent: String {
+        agentName ?? NSLocalizedString("GENERIC_AGENT", bundle: .clawsy, comment: "")
+    }
+
+    private var clipboardDescription: String {
+        if direction == .write {
+            if agentName != nil {
+                return String(format: NSLocalizedString("CLIPBOARD_NAMED_WANTS_WRITE", bundle: .clawsy, comment: ""), displayAgent)
+            }
+            return NSLocalizedString("CLIPBOARD_WANTS_WRITE", bundle: .clawsy, comment: "")
+        } else {
+            if agentName != nil {
+                return String(format: NSLocalizedString("CLIPBOARD_NAMED_WANTS_READ", bundle: .clawsy, comment: ""), displayAgent)
+            }
+            return NSLocalizedString("CLIPBOARD_WANTS_READ", bundle: .clawsy, comment: "")
+        }
+    }
+
     private func copyToSystem() {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
@@ -41,7 +60,7 @@ struct ClipboardPreviewWindow: View {
                         )
                     
                     VStack(alignment: .leading, spacing: 2) {
-                        Text(l10n: direction == .write ? "CLIPBOARD_WRITE_TITLE" : "CLIPBOARD_READ_TITLE")
+                        Text(clipboardDescription)
                             .font(.system(size: 15, weight: .semibold))
                         
                         Text("CHAR_COUNT \(charCount)")

--- a/Sources/ClawsyMac/ContentView.swift
+++ b/Sources/ClawsyMac/ContentView.swift
@@ -579,14 +579,15 @@ struct ContentView: View {
         .padding(.vertical, 6)
     }
 
-    /// Sessions eligible for the agent picker: running, not clawsy-service, main, or subagent sessions.
+    /// Sessions eligible for the agent picker: running main agent sessions only.
     private var availableAgentSessions: [GatewaySession] {
         guard let nm = network else { return [] }
         return nm.gatewaySessions.filter { session in
             session.status == "running" &&
             session.id != "clawsy-service" &&
-            !session.id.hasSuffix(":main") &&
-            !session.id.contains(":subagent:")
+            session.id.hasSuffix(":main") &&
+            !session.id.contains(":subagent:") &&
+            !session.id.contains(":cron:")
         }
     }
 
@@ -617,10 +618,20 @@ struct ContentView: View {
         if let label = session.label, !label.isEmpty {
             return label
         }
-        // Derive from key: "agent:main:slack:..." → "main"
+        // Derive from key: "agent:elliot:main" → "Elliot"
         let parts = session.id.split(separator: ":")
-        if parts.count >= 2 { return String(parts[1]) }
+        if parts.count >= 2 { return String(parts[1]).capitalized }
         return session.id
+    }
+
+    /// Derive display name from the active targetSessionKey. Returns nil for "clawsy-service" or unparseable keys.
+    private func currentAgentDisplayName() -> String? {
+        guard let nm = network else { return nil }
+        let key = nm.targetSessionKey
+        if key == "clawsy-service" { return nil }
+        let parts = key.split(separator: ":")
+        guard parts.count >= 2 else { return nil }
+        return String(parts[1]).capitalized
     }
 
         func handleManualClipboardSend() {
@@ -728,8 +739,10 @@ struct ContentView: View {
     func setupCallbacksForHost(nm: NetworkManager, profile: HostProfile) {
         nm.onScreenshotRequested = { interactive, requestId in
             DispatchQueue.main.async {
+                let agentName = self.currentAgentDisplayName()
                 self.appDelegate.showScreenshotRequest(
                     requestedInteractive: interactive,
+                    agentName: agentName,
                     onConfirm: { userInteractive in
                         if let b64 = ScreenshotManager.takeScreenshot(interactive: userInteractive) {
                             nm.sendResponse(id: requestId, result: ["format": "jpeg", "base64": b64])
@@ -746,8 +759,9 @@ struct ContentView: View {
         
         nm.onClipboardReadRequested = { requestId in
             DispatchQueue.main.async {
+                let agentName = self.currentAgentDisplayName()
                 let content = ClipboardManager.getClipboardContent() ?? ""
-                self.appDelegate.showClipboardRequest(content: content, direction: .read, onConfirm: {
+                self.appDelegate.showClipboardRequest(content: content, direction: .read, agentName: agentName, onConfirm: {
                     if let current = ClipboardManager.getClipboardContent() {
                         nm.sendResponse(id: requestId, result: ["text": current])
                     } else {
@@ -761,7 +775,8 @@ struct ContentView: View {
         
         nm.onClipboardWriteRequested = { content, requestId in
             DispatchQueue.main.async {
-                self.appDelegate.showClipboardRequest(content: content, onConfirm: {
+                let agentName = self.currentAgentDisplayName()
+                self.appDelegate.showClipboardRequest(content: content, agentName: agentName, onConfirm: {
                     ClipboardManager.setClipboardContent(content)
                     nm.sendResponse(id: requestId, result: ["status": "ok"])
                 }, onCancel: {
@@ -772,7 +787,8 @@ struct ContentView: View {
         
         nm.onFileSyncRequested = { filename, operation, onConfirm, onCancel in
             DispatchQueue.main.async {
-                self.appDelegate.showFileSyncRequest(filename: filename, operation: operation, onConfirm: { duration in
+                let agentName = self.currentAgentDisplayName()
+                self.appDelegate.showFileSyncRequest(filename: filename, operation: operation, agentName: agentName, onConfirm: { duration in
                     onConfirm(duration)
                 }, onCancel: {
                     onCancel()
@@ -781,7 +797,8 @@ struct ContentView: View {
         }
 
         nm.onCameraPreviewRequested = { image, onConfirm, onCancel in
-            self.appDelegate.showCameraPreview(image: image, onConfirm: onConfirm, onCancel: onCancel)
+            let agentName = self.currentAgentDisplayName()
+            self.appDelegate.showCameraPreview(image: image, agentName: agentName, onConfirm: onConfirm, onCancel: onCancel)
         }
         
         // Wire agent info updates only for the active host
@@ -815,8 +832,10 @@ struct ContentView: View {
     func setupCallbacksLegacy(_ network: NetworkManager) {
         network.onScreenshotRequested = { interactive, requestId in
             DispatchQueue.main.async {
+                let agentName = self.currentAgentDisplayName()
                 self.appDelegate.showScreenshotRequest(
                     requestedInteractive: interactive,
+                    agentName: agentName,
                     onConfirm: { userInteractive in
                         if let b64 = ScreenshotManager.takeScreenshot(interactive: userInteractive) {
                             network.sendResponse(id: requestId, result: ["format": "jpeg", "base64": b64])
@@ -833,8 +852,9 @@ struct ContentView: View {
         
         network.onClipboardReadRequested = { requestId in
             DispatchQueue.main.async {
+                let agentName = self.currentAgentDisplayName()
                 let content = ClipboardManager.getClipboardContent() ?? ""
-                self.appDelegate.showClipboardRequest(content: content, direction: .read, onConfirm: {
+                self.appDelegate.showClipboardRequest(content: content, direction: .read, agentName: agentName, onConfirm: {
                     if let current = ClipboardManager.getClipboardContent() {
                         network.sendResponse(id: requestId, result: ["text": current])
                     } else {
@@ -848,7 +868,8 @@ struct ContentView: View {
         
         network.onClipboardWriteRequested = { content, requestId in
             DispatchQueue.main.async {
-                self.appDelegate.showClipboardRequest(content: content, onConfirm: {
+                let agentName = self.currentAgentDisplayName()
+                self.appDelegate.showClipboardRequest(content: content, agentName: agentName, onConfirm: {
                     ClipboardManager.setClipboardContent(content)
                     network.sendResponse(id: requestId, result: ["status": "ok"])
                 }, onCancel: {
@@ -859,7 +880,8 @@ struct ContentView: View {
         
         network.onFileSyncRequested = { filename, operation, onConfirm, onCancel in
             DispatchQueue.main.async {
-                self.appDelegate.showFileSyncRequest(filename: filename, operation: operation, onConfirm: { duration in
+                let agentName = self.currentAgentDisplayName()
+                self.appDelegate.showFileSyncRequest(filename: filename, operation: operation, agentName: agentName, onConfirm: { duration in
                     onConfirm(duration)
                 }, onCancel: {
                     onCancel()
@@ -868,7 +890,8 @@ struct ContentView: View {
         }
 
         network.onCameraPreviewRequested = { image, onConfirm, onCancel in
-            self.appDelegate.showCameraPreview(image: image, onConfirm: onConfirm, onCancel: onCancel)
+            let agentName = self.currentAgentDisplayName()
+            self.appDelegate.showCameraPreview(image: image, agentName: agentName, onConfirm: onConfirm, onCancel: onCancel)
         }
     }
 }

--- a/Sources/ClawsyMac/FileSyncRequestWindow.swift
+++ b/Sources/ClawsyMac/FileSyncRequestWindow.swift
@@ -5,6 +5,7 @@ import ClawsyShared
 struct FileSyncRequestWindow: View {
     let filename: String
     let operation: String // "Upload" or "Download" or "Delete"
+    let agentName: String?
     let onConfirm: (TimeInterval?) -> Void
     let onCancel: () -> Void
 
@@ -76,6 +77,17 @@ struct FileSyncRequestWindow: View {
         }
     }
 
+    private var displayAgent: String {
+        agentName ?? NSLocalizedString("GENERIC_AGENT", bundle: .clawsy, comment: "")
+    }
+
+    private var fileSyncDescription: String {
+        if agentName != nil {
+            return String(format: NSLocalizedString("AGENT_NAMED_WANTS_TO_OP", bundle: .clawsy, comment: ""), displayAgent, operationLocalized.lowercased(), displayFilename)
+        }
+        return String(format: NSLocalizedString("AGENT_WANTS_TO_OP", bundle: .clawsy, comment: ""), operationLocalized.lowercased(), displayFilename)
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             // Header
@@ -109,7 +121,7 @@ struct FileSyncRequestWindow: View {
 
             // Content
             VStack(spacing: 12) {
-                Text(String(format: NSLocalizedString("AGENT_WANTS_TO_OP", bundle: .clawsy, comment: ""), operationLocalized.lowercased(), displayFilename))
+                Text(fileSyncDescription)
                     .font(.system(size: 13))
                     .multilineTextAlignment(.center)
 

--- a/Sources/ClawsyMac/Resources/de.lproj/Localizable.strings
+++ b/Sources/ClawsyMac/Resources/de.lproj/Localizable.strings
@@ -337,3 +337,12 @@
 "AGENT_PICKER_LABEL" = "Aktiver Agent";
 "AGENT_PICKER_DEFAULT" = "Standard (clawsy-service)";
 "NOTIFICATION_BODY_CHECKSUM" = "Prüfsumme: %@";
+
+// Agent Identity (named agent dialogs)
+"GENERIC_AGENT" = "Der Agent";
+"AGENT_NAMED_WANTS_TO" = "%@ möchte eine Datei %@.";
+"AGENT_NAMED_WANTS_TO_OP" = "%@ möchte die Datei „%@" %@.";
+"CLIPBOARD_NAMED_WANTS_WRITE" = "%@ möchte in deine Zwischenablage schreiben:";
+"CLIPBOARD_NAMED_WANTS_READ" = "%@ möchte deine Zwischenablage lesen.";
+"ALERT_SCREENSHOT_NAMED_BODY" = "%@ möchte deinen Bildschirm sehen.";
+"REMOTE_NAMED_USER_ASKING" = "%@ bittet um eine Aufnahme.";

--- a/Sources/ClawsyMac/Resources/en.lproj/Localizable.strings
+++ b/Sources/ClawsyMac/Resources/en.lproj/Localizable.strings
@@ -336,3 +336,12 @@
 "AGENT_PICKER_LABEL" = "Active Agent";
 "AGENT_PICKER_DEFAULT" = "Default (clawsy-service)";
 "NOTIFICATION_BODY_CHECKSUM" = "Checksum: %@";
+
+// Agent Identity (named agent dialogs)
+"GENERIC_AGENT" = "The agent";
+"AGENT_NAMED_WANTS_TO" = "%@ wants to %@ a file.";
+"AGENT_NAMED_WANTS_TO_OP" = "%@ wants to %@ the file \"%@\".";
+"CLIPBOARD_NAMED_WANTS_WRITE" = "%@ wants to write to your clipboard:";
+"CLIPBOARD_NAMED_WANTS_READ" = "%@ wants to read your clipboard.";
+"ALERT_SCREENSHOT_NAMED_BODY" = "%@ wants to see your screen.";
+"REMOTE_NAMED_USER_ASKING" = "%@ is requesting a capture.";

--- a/Sources/ClawsyMac/Resources/es.lproj/Localizable.strings
+++ b/Sources/ClawsyMac/Resources/es.lproj/Localizable.strings
@@ -335,3 +335,12 @@
 "AGENT_PICKER_LABEL" = "Agente activo";
 "AGENT_PICKER_DEFAULT" = "Por defecto (clawsy-service)";
 "NOTIFICATION_BODY_CHECKSUM" = "Suma de verificación: %@";
+
+// Agent Identity (named agent dialogs)
+"GENERIC_AGENT" = "El agente";
+"AGENT_NAMED_WANTS_TO" = "%@ quiere %@ un archivo.";
+"AGENT_NAMED_WANTS_TO_OP" = "%@ quiere %@ el archivo «%@».";
+"CLIPBOARD_NAMED_WANTS_WRITE" = "%@ quiere escribir en tu portapapeles:";
+"CLIPBOARD_NAMED_WANTS_READ" = "%@ quiere leer tu portapapeles.";
+"ALERT_SCREENSHOT_NAMED_BODY" = "%@ quiere ver tu pantalla.";
+"REMOTE_NAMED_USER_ASKING" = "%@ solicita una captura.";

--- a/Sources/ClawsyMac/Resources/fr.lproj/Localizable.strings
+++ b/Sources/ClawsyMac/Resources/fr.lproj/Localizable.strings
@@ -335,3 +335,12 @@
 "AGENT_PICKER_LABEL" = "Agent actif";
 "AGENT_PICKER_DEFAULT" = "Par défaut (clawsy-service)";
 "NOTIFICATION_BODY_CHECKSUM" = "Somme de contrôle : %@";
+
+// Agent Identity (named agent dialogs)
+"GENERIC_AGENT" = "L'agent";
+"AGENT_NAMED_WANTS_TO" = "%@ veut %@ un fichier.";
+"AGENT_NAMED_WANTS_TO_OP" = "%@ veut %@ le fichier « %@ ».";
+"CLIPBOARD_NAMED_WANTS_WRITE" = "%@ veut écrire dans votre presse-papiers :";
+"CLIPBOARD_NAMED_WANTS_READ" = "%@ veut lire votre presse-papiers.";
+"ALERT_SCREENSHOT_NAMED_BODY" = "%@ veut voir votre écran.";
+"REMOTE_NAMED_USER_ASKING" = "%@ demande une capture.";

--- a/Sources/ClawsyMac/ScreenshotRequestWindow.swift
+++ b/Sources/ClawsyMac/ScreenshotRequestWindow.swift
@@ -3,8 +3,20 @@ import AppKit
 
 struct ScreenshotRequestWindow: View {
     let requestedInteractive: Bool
+    let agentName: String?
     let onConfirm: (Bool) -> Void // Bool = interactive
     let onCancel: () -> Void
+
+    private var displayAgent: String {
+        agentName ?? NSLocalizedString("GENERIC_AGENT", bundle: .clawsy, comment: "")
+    }
+
+    private var remoteUserText: String {
+        if agentName != nil {
+            return String(format: NSLocalizedString("REMOTE_NAMED_USER_ASKING", bundle: .clawsy, comment: ""), displayAgent)
+        }
+        return NSLocalizedString("REMOTE_USER_ASKING", bundle: .clawsy, comment: "")
+    }
     
     var body: some View {
         VStack(spacing: 0) {
@@ -25,7 +37,7 @@ struct ScreenshotRequestWindow: View {
                     Text("SCREENSHOT_REQUEST")
                         .font(.system(size: 15, weight: .bold))
                     
-                    Text("REMOTE_USER_ASKING")
+                    Text(remoteUserText)
                         .font(.system(size: 11, weight: .medium))
                         .foregroundColor(.secondary)
                 }

--- a/Sources/ClawsyMac/ScreenshotRunner.swift
+++ b/Sources/ClawsyMac/ScreenshotRunner.swift
@@ -84,6 +84,7 @@ enum ScreenshotRunner {
         let view = FileSyncRequestWindow(
             filename: "report_2026.pdf",
             operation: "Upload",
+            agentName: nil,
             onConfirm: { _ in },
             onCancel: {}
         )

--- a/Sources/ClawsyShared/Resources/de.lproj/Localizable.strings
+++ b/Sources/ClawsyShared/Resources/de.lproj/Localizable.strings
@@ -345,3 +345,12 @@
 // Agent Picker
 "AGENT_PICKER_LABEL" = "Aktiver Agent";
 "AGENT_PICKER_DEFAULT" = "Standard (clawsy-service)";
+
+// Agent Identity (named agent dialogs)
+"GENERIC_AGENT" = "Der Agent";
+"AGENT_NAMED_WANTS_TO" = "%@ möchte eine Datei %@.";
+"AGENT_NAMED_WANTS_TO_OP" = "%@ möchte die Datei „%@" %@.";
+"CLIPBOARD_NAMED_WANTS_WRITE" = "%@ möchte in deine Zwischenablage schreiben:";
+"CLIPBOARD_NAMED_WANTS_READ" = "%@ möchte deine Zwischenablage lesen.";
+"ALERT_SCREENSHOT_NAMED_BODY" = "%@ möchte deinen Bildschirm sehen.";
+"REMOTE_NAMED_USER_ASKING" = "%@ bittet um eine Aufnahme.";

--- a/Sources/ClawsyShared/Resources/en.lproj/Localizable.strings
+++ b/Sources/ClawsyShared/Resources/en.lproj/Localizable.strings
@@ -344,3 +344,12 @@
 // Agent Picker
 "AGENT_PICKER_LABEL" = "Active Agent";
 "AGENT_PICKER_DEFAULT" = "Default (clawsy-service)";
+
+// Agent Identity (named agent dialogs)
+"GENERIC_AGENT" = "The agent";
+"AGENT_NAMED_WANTS_TO" = "%@ wants to %@ a file.";
+"AGENT_NAMED_WANTS_TO_OP" = "%@ wants to %@ the file \"%@\".";
+"CLIPBOARD_NAMED_WANTS_WRITE" = "%@ wants to write to your clipboard:";
+"CLIPBOARD_NAMED_WANTS_READ" = "%@ wants to read your clipboard.";
+"ALERT_SCREENSHOT_NAMED_BODY" = "%@ wants to see your screen.";
+"REMOTE_NAMED_USER_ASKING" = "%@ is requesting a capture.";

--- a/Sources/ClawsyShared/Resources/es.lproj/Localizable.strings
+++ b/Sources/ClawsyShared/Resources/es.lproj/Localizable.strings
@@ -297,3 +297,12 @@
 // Agent Picker
 "AGENT_PICKER_LABEL" = "Agente activo";
 "AGENT_PICKER_DEFAULT" = "Por defecto (clawsy-service)";
+
+// Agent Identity (named agent dialogs)
+"GENERIC_AGENT" = "El agente";
+"AGENT_NAMED_WANTS_TO" = "%@ quiere %@ un archivo.";
+"AGENT_NAMED_WANTS_TO_OP" = "%@ quiere %@ el archivo «%@».";
+"CLIPBOARD_NAMED_WANTS_WRITE" = "%@ quiere escribir en tu portapapeles:";
+"CLIPBOARD_NAMED_WANTS_READ" = "%@ quiere leer tu portapapeles.";
+"ALERT_SCREENSHOT_NAMED_BODY" = "%@ quiere ver tu pantalla.";
+"REMOTE_NAMED_USER_ASKING" = "%@ solicita una captura.";

--- a/Sources/ClawsyShared/Resources/fr.lproj/Localizable.strings
+++ b/Sources/ClawsyShared/Resources/fr.lproj/Localizable.strings
@@ -297,3 +297,12 @@
 // Agent Picker
 "AGENT_PICKER_LABEL" = "Agent actif";
 "AGENT_PICKER_DEFAULT" = "Par défaut (clawsy-service)";
+
+// Agent Identity (named agent dialogs)
+"GENERIC_AGENT" = "L'agent";
+"AGENT_NAMED_WANTS_TO" = "%@ veut %@ un fichier.";
+"AGENT_NAMED_WANTS_TO_OP" = "%@ veut %@ le fichier « %@ ».";
+"CLIPBOARD_NAMED_WANTS_WRITE" = "%@ veut écrire dans votre presse-papiers :";
+"CLIPBOARD_NAMED_WANTS_READ" = "%@ veut lire votre presse-papiers.";
+"ALERT_SCREENSHOT_NAMED_BODY" = "%@ veut voir votre écran.";
+"REMOTE_NAMED_USER_ASKING" = "%@ demande une capture.";


### PR DESCRIPTION
## Changes

### Issue #37: Agent Picker Filter Fix
- Fixed `availableAgentSessions` filter: changed `!hasSuffix(":main")` to `hasSuffix(":main")` so only main agent sessions appear in the picker
- Added `:cron:` exclusion filter
- Capitalized agent display names (`agent:elliot:main` -> `Elliot`)

### Issue #38: Agent Name in Permission Dialogs
- Added `currentAgentDisplayName()` helper to derive display name from `targetSessionKey`
- Added `agentName: String?` parameter to all permission dialog views:
  - `FileSyncRequestWindow`
  - `ClipboardPreviewWindow`
  - `ScreenshotRequestWindow`
  - `CameraPreviewView`
- Added `GENERIC_AGENT` fallback for single-agent setups ("The agent" / "Der Agent" / "L'agent" / "El agente")
- Added named agent L10N strings (`AGENT_NAMED_WANTS_TO_OP`, `CLIPBOARD_NAMED_WANTS_WRITE/READ`, `REMOTE_NAMED_USER_ASKING`, etc.) to all 4 locales x 2 bundles (8 files)
- Wired `agentName` through from `ContentView` callbacks (`setupCallbacksForHost` + `setupCallbacksLegacy`) to `AppDelegate.show*` methods

Closes #37
Closes #38