### PR TITLE
fix: correct format arg order + restore clipboard title text

### DIFF
--- a/Sources/ClawsyMac/ClipboardPreviewWindow.swift
+++ b/Sources/ClawsyMac/ClipboardPreviewWindow.swift
@@ -21,17 +21,17 @@ struct ClipboardPreviewWindow: View {
         agentName ?? NSLocalizedString("GENERIC_AGENT", bundle: .clawsy, comment: "")
     }
 
-    private var clipboardDescription: String {
+    private var clipboardTitle: String {
         if direction == .write {
-            if agentName != nil {
-                return String(format: NSLocalizedString("CLIPBOARD_NAMED_WANTS_WRITE", bundle: .clawsy, comment: ""), displayAgent)
+            if let name = agentName {
+                return String(format: NSLocalizedString("CLIPBOARD_NAMED_WRITE_TITLE", bundle: .clawsy, comment: ""), name)
             }
-            return NSLocalizedString("CLIPBOARD_WANTS_WRITE", bundle: .clawsy, comment: "")
+            return NSLocalizedString("CLIPBOARD_WRITE_TITLE", bundle: .clawsy, comment: "")
         } else {
-            if agentName != nil {
-                return String(format: NSLocalizedString("CLIPBOARD_NAMED_WANTS_READ", bundle: .clawsy, comment: ""), displayAgent)
+            if let name = agentName {
+                return String(format: NSLocalizedString("CLIPBOARD_NAMED_READ_TITLE", bundle: .clawsy, comment: ""), name)
             }
-            return NSLocalizedString("CLIPBOARD_WANTS_READ", bundle: .clawsy, comment: "")
+            return NSLocalizedString("CLIPBOARD_READ_TITLE", bundle: .clawsy, comment: "")
         }
     }
 
@@ -60,7 +60,7 @@ struct ClipboardPreviewWindow: View {
                         )
                     
                     VStack(alignment: .leading, spacing: 2) {
-                        Text(clipboardDescription)
+                        Text(clipboardTitle)
                             .font(.system(size: 15, weight: .semibold))
                         
                         Text("CHAR_COUNT \(charCount)")

--- a/Sources/ClawsyMac/FileSyncRequestWindow.swift
+++ b/Sources/ClawsyMac/FileSyncRequestWindow.swift
@@ -83,9 +83,9 @@ struct FileSyncRequestWindow: View {
 
     private var fileSyncDescription: String {
         if agentName != nil {
-            return String(format: NSLocalizedString("AGENT_NAMED_WANTS_TO_OP", bundle: .clawsy, comment: ""), displayAgent, operationLocalized.lowercased(), displayFilename)
+            return String(format: NSLocalizedString("AGENT_NAMED_WANTS_TO_OP", bundle: .clawsy, comment: ""), displayAgent, displayFilename, operationLocalized.lowercased())
         }
-        return String(format: NSLocalizedString("AGENT_WANTS_TO_OP", bundle: .clawsy, comment: ""), operationLocalized.lowercased(), displayFilename)
+        return String(format: NSLocalizedString("AGENT_WANTS_TO_OP", bundle: .clawsy, comment: ""), displayFilename, operationLocalized.lowercased())
     }
 
     var body: some View {

--- a/Sources/ClawsyMac/Resources/de.lproj/Localizable.strings
+++ b/Sources/ClawsyMac/Resources/de.lproj/Localizable.strings
@@ -146,7 +146,7 @@
 "STATUS_PAIRING" = "Kopplung…";
 "STATUS_PAIRING_PENDING" = "Warte auf Kopplung…";
 "STATUS_PAIRING_REJECTED" = "Kopplung abgelehnt";
-"STATUS_PAIRING_TIMEOUT" = "Kopplung – Zeitüberschreitung";
+"STATUS_PAIRING_TIMEOUT" = "Kopplung - Zeitüberschreitung";
 "STATUS_AWAITING_PAIR_APPROVE" = "Freigabe ausstehend";
 "PAIRING_REQUIRED_TITLE" = "Pairing-Bestätigung erforderlich";
 "PAIRING_REQUIRED_DESC" = "Führe diesen Befehl auf deinem Server aus:";
@@ -204,17 +204,19 @@
 "ONBOARDING_SKIP" = "Später";
 "ONBOARDING_DONE" = "Fertig";
 "RULE_NOTIFY_TITLE" = "Clawsy Regel ausgelöst";
-"ONBOARDING_ACCESSIBILITY_RESTART_HINT" = "Clawsy ist in Bedienungshilfen aktiviert ✓ — ein Neustart ist erforderlich, damit der Zugriff wirksam wird.";
+"ONBOARDING_ACCESSIBILITY_RESTART_HINT" = "Clawsy ist in Bedienungshilfen aktiviert ✓ - ein Neustart ist erforderlich, damit der Zugriff wirksam wird.";
 "ONBOARDING_RESTART" = "Jetzt neu starten";
 "ONBOARDING_ACCESSIBILITY_SKIP_RESTART" = "Ich habe Zugriff erteilt, ohne Neustart fortfahren →";
 "MISSION_CONTROL_EMPTY" = "Keine aktiven Aufgaben";
 "MISSION_CONTROL_EMPTY_HINT" = "Sobald dein Assistent eine Aufgabe bearbeitet, erscheint sie hier.";
 "FILESYNC_TITLE" = "Dateizugriff angefragt";
-"FILESYNC_WINDOW_TITLE" = "Clawsy — Dateizugriff";
+"FILESYNC_WINDOW_TITLE" = "Clawsy - Dateizugriff";
 "OP_UPLOAD" = "Hochladen";
 "OP_DOWNLOAD" = "Herunterladen";
 "OP_DELETE" = "Löschen";
-"AGENT_WANTS_TO_OP" = "Der Agent möchte die Datei „%@“ %@.";
+"AGENT_WANTS_TO_OP" = "Der Agent möchte die Datei „%1$@“ %2$@.";
+"CLIPBOARD_NAMED_WRITE_TITLE" = "%@ möchte in die Zwischenablage schreiben";
+"CLIPBOARD_NAMED_READ_TITLE" = "%@ möchte die Zwischenablage lesen";
 "FILENAME_AGENT_STATUS" = "Agentenstatus (intern)";
 "ALLOW_LIMITED" = "Zeitlich erlauben…";
 "ALLOW_UPLOAD" = "Hochladen erlauben";
@@ -257,14 +259,14 @@
 "STATUS_RECONNECTING" = "Verbindung wird wiederhergestellt…";
 "STATUS_RECONNECT_EXHAUSTED" = "Verbindung fehlgeschlagen";
 
-// Onboarding – Teilen-Erweiterung
+// Onboarding - Teilen-Erweiterung
 "ONBOARDING_SHARE" = "Teilen-Erweiterung";
 "ONBOARDING_SHARE_DESC" = "Nutze das Teilen-Menü in jeder App, um Dateien oder Text direkt an deinen Agent zu senden. Automatisch verfügbar, wenn Clawsy in /Programme liegt.";
 "ONBOARDING_SHARE_ACTION" = "Verstanden";
 
-// Onboarding – Server einrichten
+// Onboarding - Server einrichten
 "ONBOARDING_SERVER" = "Server einrichten";
-"ONBOARDING_SERVER_DESC" = "Dein Agent braucht Server-Komponenten, um Zwischenablage und Screenshots zu cachen. Tippe, um einen Setup-Prompt zu kopieren — sende ihn deinem Agent per Chat.";
+"ONBOARDING_SERVER_DESC" = "Dein Agent braucht Server-Komponenten, um Zwischenablage und Screenshots zu cachen. Tippe, um einen Setup-Prompt zu kopieren - sende ihn deinem Agent per Chat.";
 "ONBOARDING_SERVER_COPY" = "Setup-Prompt kopieren";
 "ONBOARDING_SERVER_DONE" = "Fertig";
 
@@ -289,13 +291,13 @@
 "ONBOARDING_INSTALL_SUBTITLE" = "Schick diesen Befehl deinem Agenten, um den Clawsy-Server zu installieren.";
 "ONBOARDING_INSTALL_STEP1" = "1. Kopiere diesen Befehl und schicke ihn deinem Agenten (Telegram, Slack, etc.):";
 "ONBOARDING_INSTALL_STEP2" = "2. Dein Agent installiert Clawsy und schickt dir einen Link zum Klicken zurück.";
-"ONBOARDING_INSTALL_SENT" = "Gesendet — ich warte auf den Link";
+"ONBOARDING_INSTALL_SENT" = "Gesendet - ich warte auf den Link";
 "ONBOARDING_INSTALL_WAITING" = "Warte auf den Link von deinem Agenten…";
 "ONBOARDING_INSTALL_WAITING_HINT" = "Klicke den clawsy://-Link den dein Agent schickt. Clawsy verbindet sich automatisch.";
 "ONBOARDING_INSTALL_BACK" = "← Zurück";
 "ONBOARDING_GATEWAY_HAVE_CODE" = "Code bereits vorhanden? →";
 
-// v0.9.3 — Onboarding Install-Prompt & Case B
+// v0.9.3 - Onboarding Install-Prompt & Case B
 "ONBOARDING_INSTALL_PROMPT_FULL" = "Bitte installiere den Clawsy-Server auf dieser OpenClaw-Instanz:\n\ncurl -fsSL https://raw.githubusercontent.com/iret77/clawsy/main/server/install.sh | bash\n\nDas Skript richtet alles ein und sendet dir automatisch einen Setup-Link über deinen üblichen Messaging-Kanal (Telegram, Slack, etc.). Klicke diesen Link auf deinem Mac, um die Verbindung herzustellen.";
 "ONBOARDING_INSTALL_CASE_B_SUBTITLE" = "Verbunden, aber Clawsy-Server ist noch nicht installiert.";
 
@@ -312,18 +314,18 @@
 "NO_HOST_SUBTITLE" = "Füge einen Host hinzu um loszulegen.";
 "NO_HOST_ADD_BUTTON" = "Host hinzufügen";
 
-"CONNECTION_HELP" = "Bitte deinen Agenten, einen Verbindungslink zu generieren – oder entnimm Host, Port und Token aus deiner OpenClaw-Serverkonfiguration.";
+"CONNECTION_HELP" = "Bitte deinen Agenten, einen Verbindungslink zu generieren - oder entnimm Host, Port und Token aus deiner OpenClaw-Serverkonfiguration.";
 "CONNECTION_GUIDE_TITLE" = "So verbindest du einen neuen Host:";
 "CONNECTION_GUIDE_STEP1" = "Sag deinem Agenten: \"Installiere das Clawsy-Serverpaket\" (clawhub install clawsy)";
-"CONNECTION_GUIDE_STEP2" = "Dein Agent schickt dir einen Verbindungslink – klick ihn an und Clawsy verbindet sich automatisch.";
+"CONNECTION_GUIDE_STEP2" = "Dein Agent schickt dir einen Verbindungslink - klick ihn an und Clawsy verbindet sich automatisch.";
 "STATUS_RECONNECT_COUNTDOWN %lld" = "Neuverbindung in %lld s…";
 
-// Onboarding UX — Skill fehlt nach SSH (v0.9.4)
-"ERROR_SKILL_MISSING_TITLE" = "SSH verbunden — Clawsy-Skill fehlt";
-"ERROR_SKILL_MISSING_DESC" = "SSH-Verbindung erfolgreich — aber der Clawsy-Server-Skill ist auf dieser OpenClaw-Instanz nicht installiert.";
+// Onboarding UX - Skill fehlt nach SSH (v0.9.4)
+"ERROR_SKILL_MISSING_TITLE" = "SSH verbunden - Clawsy-Skill fehlt";
+"ERROR_SKILL_MISSING_DESC" = "SSH-Verbindung erfolgreich - aber der Clawsy-Server-Skill ist auf dieser OpenClaw-Instanz nicht installiert.";
 "ERROR_SKILL_MISSING_FIX_PROMPT" = "Installiere den Clawsy-Skill von clawhub";
 
-// Host hinzufügen — Agent-Hilfe-Hinweis im manuellen Modus
+// Host hinzufügen - Agent-Hilfe-Hinweis im manuellen Modus
 "ADD_HOST_MANUAL_HINT_TITLE" = "Verbindungsdaten unbekannt?";
 "ADD_HOST_MANUAL_HINT_DESC" = "Sag deinem OpenClaw-Agenten:";
 "ADD_HOST_MANUAL_HINT_PROMPT" = "Installiere den Clawsy-Skill von clawhub";
@@ -341,7 +343,7 @@
 // Agent Identity (named agent dialogs)
 "GENERIC_AGENT" = "Der Agent";
 "AGENT_NAMED_WANTS_TO" = "%@ möchte eine Datei %@.";
-"AGENT_NAMED_WANTS_TO_OP" = "%@ möchte die Datei „%@" %@.";
+"AGENT_NAMED_WANTS_TO_OP" = "%1$@ möchte die Datei „%2$@“ %3$@.";
 "CLIPBOARD_NAMED_WANTS_WRITE" = "%@ möchte in deine Zwischenablage schreiben:";
 "CLIPBOARD_NAMED_WANTS_READ" = "%@ möchte deine Zwischenablage lesen.";
 "ALERT_SCREENSHOT_NAMED_BODY" = "%@ möchte deinen Bildschirm sehen.";

--- a/Sources/ClawsyMac/Resources/en.lproj/Localizable.strings
+++ b/Sources/ClawsyMac/Resources/en.lproj/Localizable.strings
@@ -213,7 +213,9 @@
 "OP_UPLOAD" = "Upload";
 "OP_DOWNLOAD" = "Download";
 "OP_DELETE" = "Delete";
-"AGENT_WANTS_TO_OP" = "The agent wants to %@ the file \"%@\".";
+"AGENT_WANTS_TO_OP" = "The agent wants to %2$@ the file \"%1$@\".";
+"CLIPBOARD_NAMED_WRITE_TITLE" = "%@ wants to write to clipboard";
+"CLIPBOARD_NAMED_READ_TITLE" = "%@ wants to read clipboard";
 "FILENAME_AGENT_STATUS" = "Agent Status (internal)";
 "ALLOW_LIMITED" = "Allow for…";
 "ALLOW_UPLOAD" = "Allow Upload";
@@ -340,7 +342,7 @@
 // Agent Identity (named agent dialogs)
 "GENERIC_AGENT" = "The agent";
 "AGENT_NAMED_WANTS_TO" = "%@ wants to %@ a file.";
-"AGENT_NAMED_WANTS_TO_OP" = "%@ wants to %@ the file \"%@\".";
+"AGENT_NAMED_WANTS_TO_OP" = "%1$@ wants to %3$@ the file \"%2$@\".";
 "CLIPBOARD_NAMED_WANTS_WRITE" = "%@ wants to write to your clipboard:";
 "CLIPBOARD_NAMED_WANTS_READ" = "%@ wants to read your clipboard.";
 "ALERT_SCREENSHOT_NAMED_BODY" = "%@ wants to see your screen.";

--- a/Sources/ClawsyMac/Resources/es.lproj/Localizable.strings
+++ b/Sources/ClawsyMac/Resources/es.lproj/Localizable.strings
@@ -213,7 +213,9 @@
 "OP_UPLOAD" = "Subir";
 "OP_DOWNLOAD" = "Descargar";
 "OP_DELETE" = "Eliminar";
-"AGENT_WANTS_TO_OP" = "El agente quiere %@ el archivo «%@».";
+"AGENT_WANTS_TO_OP" = "El agente quiere %2$@ el archivo «%1$@».";
+"CLIPBOARD_NAMED_WRITE_TITLE" = "%@ quiere escribir en el portapapeles";
+"CLIPBOARD_NAMED_READ_TITLE" = "%@ quiere leer el portapapeles";
 "FILENAME_AGENT_STATUS" = "Estado del agente (interno)";
 "ALLOW_LIMITED" = "Permitir por…";
 "ALLOW_UPLOAD" = "Permitir subida";
@@ -339,7 +341,7 @@
 // Agent Identity (named agent dialogs)
 "GENERIC_AGENT" = "El agente";
 "AGENT_NAMED_WANTS_TO" = "%@ quiere %@ un archivo.";
-"AGENT_NAMED_WANTS_TO_OP" = "%@ quiere %@ el archivo «%@».";
+"AGENT_NAMED_WANTS_TO_OP" = "%1$@ quiere %3$@ el archivo «%2$@».";
 "CLIPBOARD_NAMED_WANTS_WRITE" = "%@ quiere escribir en tu portapapeles:";
 "CLIPBOARD_NAMED_WANTS_READ" = "%@ quiere leer tu portapapeles.";
 "ALERT_SCREENSHOT_NAMED_BODY" = "%@ quiere ver tu pantalla.";

--- a/Sources/ClawsyMac/Resources/fr.lproj/Localizable.strings
+++ b/Sources/ClawsyMac/Resources/fr.lproj/Localizable.strings
@@ -213,7 +213,9 @@
 "OP_UPLOAD" = "Envoyer";
 "OP_DOWNLOAD" = "Télécharger";
 "OP_DELETE" = "Supprimer";
-"AGENT_WANTS_TO_OP" = "L'agent veut %@ le fichier « %@ ».";
+"AGENT_WANTS_TO_OP" = "L'agent veut %2$@ le fichier « %1$@ ».";
+"CLIPBOARD_NAMED_WRITE_TITLE" = "%@ veut écrire dans le presse-papiers";
+"CLIPBOARD_NAMED_READ_TITLE" = "%@ veut lire le presse-papiers";
 "FILENAME_AGENT_STATUS" = "Statut de l'agent (interne)";
 "ALLOW_LIMITED" = "Autoriser pour…";
 "ALLOW_UPLOAD" = "Autoriser l'envoi";
@@ -339,7 +341,7 @@
 // Agent Identity (named agent dialogs)
 "GENERIC_AGENT" = "L'agent";
 "AGENT_NAMED_WANTS_TO" = "%@ veut %@ un fichier.";
-"AGENT_NAMED_WANTS_TO_OP" = "%@ veut %@ le fichier « %@ ».";
+"AGENT_NAMED_WANTS_TO_OP" = "%1$@ veut %3$@ le fichier « %2$@ ».";
 "CLIPBOARD_NAMED_WANTS_WRITE" = "%@ veut écrire dans votre presse-papiers :";
 "CLIPBOARD_NAMED_WANTS_READ" = "%@ veut lire votre presse-papiers.";
 "ALERT_SCREENSHOT_NAMED_BODY" = "%@ veut voir votre écran.";

--- a/Sources/ClawsyShared/Resources/de.lproj/Localizable.strings
+++ b/Sources/ClawsyShared/Resources/de.lproj/Localizable.strings
@@ -149,7 +149,7 @@
 "STATUS_PAIRING" = "Kopplung…";
 "STATUS_PAIRING_PENDING" = "Warte auf Kopplung…";
 "STATUS_PAIRING_REJECTED" = "Kopplung abgelehnt";
-"STATUS_PAIRING_TIMEOUT" = "Kopplung – Zeitüberschreitung";
+"STATUS_PAIRING_TIMEOUT" = "Kopplung - Zeitüberschreitung";
 "STATUS_AWAITING_PAIR_APPROVE" = "Freigabe ausstehend";
 "PAIRING_REQUIRED_TITLE" = "Pairing-Bestätigung erforderlich";
 "PAIRING_REQUIRED_DESC" = "Führe diesen Befehl auf deinem Server aus:";
@@ -208,17 +208,19 @@
 "ONBOARDING_SKIP" = "Später";
 "ONBOARDING_DONE" = "Fertig";
 "RULE_NOTIFY_TITLE" = "Clawsy Regel ausgelöst";
-"ONBOARDING_ACCESSIBILITY_RESTART_HINT" = "Clawsy ist in Bedienungshilfen aktiviert ✓ — ein Neustart ist erforderlich, damit der Zugriff wirksam wird.";
+"ONBOARDING_ACCESSIBILITY_RESTART_HINT" = "Clawsy ist in Bedienungshilfen aktiviert ✓ - ein Neustart ist erforderlich, damit der Zugriff wirksam wird.";
 "ONBOARDING_RESTART" = "Jetzt neu starten";
 "ONBOARDING_ACCESSIBILITY_SKIP_RESTART" = "Ich habe Zugriff erteilt, ohne Neustart fortfahren →";
 "MISSION_CONTROL_EMPTY" = "Keine aktiven Aufgaben";
 "MISSION_CONTROL_EMPTY_HINT" = "Sobald dein Assistent eine Aufgabe bearbeitet, erscheint sie hier.";
 "FILESYNC_TITLE" = "Dateizugriff angefragt";
-"FILESYNC_WINDOW_TITLE" = "Clawsy — Dateizugriff";
+"FILESYNC_WINDOW_TITLE" = "Clawsy - Dateizugriff";
 "OP_UPLOAD" = "Hochladen";
 "OP_DOWNLOAD" = "Herunterladen";
 "OP_DELETE" = "Löschen";
-"AGENT_WANTS_TO_OP" = "Der Agent möchte die Datei „%@“ %@.";
+"AGENT_WANTS_TO_OP" = "Der Agent möchte die Datei „%1$@“ %2$@.";
+"CLIPBOARD_NAMED_WRITE_TITLE" = "%@ möchte in die Zwischenablage schreiben";
+"CLIPBOARD_NAMED_READ_TITLE" = "%@ möchte die Zwischenablage lesen";
 "FILENAME_AGENT_STATUS" = "Agentenstatus (intern)";
 "ALLOW_LIMITED" = "Zeitlich erlauben…";
 "ALLOW_UPLOAD" = "Hochladen erlauben";
@@ -261,14 +263,14 @@
 "STATUS_RECONNECTING" = "Verbindung wird wiederhergestellt…";
 "STATUS_RECONNECT_EXHAUSTED" = "Verbindung fehlgeschlagen";
 
-// Onboarding – Teilen-Erweiterung
+// Onboarding - Teilen-Erweiterung
 "ONBOARDING_SHARE" = "Teilen-Erweiterung";
 "ONBOARDING_SHARE_DESC" = "Nutze das Teilen-Menü in jeder App, um Dateien oder Text direkt an deinen Agent zu senden. Automatisch verfügbar, wenn Clawsy in /Programme liegt.";
 "ONBOARDING_SHARE_ACTION" = "Verstanden";
 
-// Onboarding – Server einrichten
+// Onboarding - Server einrichten
 "ONBOARDING_SERVER" = "Server einrichten";
-"ONBOARDING_SERVER_DESC" = "Dein Agent braucht Server-Komponenten, um Zwischenablage und Screenshots zu cachen. Tippe, um einen Setup-Prompt zu kopieren — sende ihn deinem Agent per Chat.";
+"ONBOARDING_SERVER_DESC" = "Dein Agent braucht Server-Komponenten, um Zwischenablage und Screenshots zu cachen. Tippe, um einen Setup-Prompt zu kopieren - sende ihn deinem Agent per Chat.";
 "ONBOARDING_SERVER_COPY" = "Setup-Prompt kopieren";
 "ONBOARDING_SERVER_DONE" = "Fertig";
 
@@ -298,13 +300,13 @@
 "ONBOARDING_INSTALL_SUBTITLE" = "Schick diesen Befehl deinem Agenten, um den Clawsy-Server zu installieren.";
 "ONBOARDING_INSTALL_STEP1" = "1. Kopiere diesen Befehl und schicke ihn deinem Agenten (Telegram, Slack, etc.):";
 "ONBOARDING_INSTALL_STEP2" = "2. Dein Agent installiert Clawsy und schickt dir einen Link zum Klicken zurück.";
-"ONBOARDING_INSTALL_SENT" = "Gesendet — ich warte auf den Link";
+"ONBOARDING_INSTALL_SENT" = "Gesendet - ich warte auf den Link";
 "ONBOARDING_INSTALL_WAITING" = "Warte auf den Link von deinem Agenten…";
 "ONBOARDING_INSTALL_WAITING_HINT" = "Klicke den clawsy://-Link den dein Agent schickt. Clawsy verbindet sich automatisch.";
 "ONBOARDING_INSTALL_BACK" = "← Zurück";
 "ONBOARDING_GATEWAY_HAVE_CODE" = "Code bereits vorhanden? →";
 
-// v0.9.3 — Onboarding Install-Prompt & Case B
+// v0.9.3 - Onboarding Install-Prompt & Case B
 "ONBOARDING_INSTALL_PROMPT_FULL" = "Bitte installiere den Clawsy-Server auf dieser OpenClaw-Instanz:\n\ncurl -fsSL https://raw.githubusercontent.com/iret77/clawsy/main/server/install.sh | bash\n\nDas Skript richtet alles ein und sendet dir automatisch einen Setup-Link über deinen üblichen Messaging-Kanal (Telegram, Slack, etc.). Klicke diesen Link auf deinem Mac, um die Verbindung herzustellen.";
 "ONBOARDING_INSTALL_CASE_B_SUBTITLE" = "Verbunden, aber Clawsy-Server ist noch nicht installiert.";
 
@@ -321,18 +323,18 @@
 "NO_HOST_SUBTITLE" = "Füge einen Host hinzu um loszulegen.";
 "NO_HOST_ADD_BUTTON" = "Host hinzufügen";
 
-"CONNECTION_HELP" = "Bitte deinen Agenten, einen Verbindungslink zu generieren – oder entnimm Host, Port und Token aus deiner OpenClaw-Serverkonfiguration.";
+"CONNECTION_HELP" = "Bitte deinen Agenten, einen Verbindungslink zu generieren - oder entnimm Host, Port und Token aus deiner OpenClaw-Serverkonfiguration.";
 "CONNECTION_GUIDE_TITLE" = "So verbindest du einen neuen Host:";
 "CONNECTION_GUIDE_STEP1" = "Sag deinem Agenten: \"Installiere das Clawsy-Serverpaket\" (clawhub install clawsy)";
-"CONNECTION_GUIDE_STEP2" = "Dein Agent schickt dir einen Verbindungslink – klick ihn an und Clawsy verbindet sich automatisch.";
+"CONNECTION_GUIDE_STEP2" = "Dein Agent schickt dir einen Verbindungslink - klick ihn an und Clawsy verbindet sich automatisch.";
 "STATUS_RECONNECT_COUNTDOWN %lld" = "Neuverbindung in %lld s…";
 
-// Onboarding UX — Skill fehlt nach SSH (v0.9.4)
-"ERROR_SKILL_MISSING_TITLE" = "SSH verbunden — Clawsy-Skill fehlt";
-"ERROR_SKILL_MISSING_DESC" = "SSH-Verbindung erfolgreich — aber der Clawsy-Server-Skill ist auf dieser OpenClaw-Instanz nicht installiert.";
+// Onboarding UX - Skill fehlt nach SSH (v0.9.4)
+"ERROR_SKILL_MISSING_TITLE" = "SSH verbunden - Clawsy-Skill fehlt";
+"ERROR_SKILL_MISSING_DESC" = "SSH-Verbindung erfolgreich - aber der Clawsy-Server-Skill ist auf dieser OpenClaw-Instanz nicht installiert.";
 "ERROR_SKILL_MISSING_FIX_PROMPT" = "Installiere den Clawsy-Skill von clawhub";
 
-// Host hinzufügen — Agent-Hilfe-Hinweis im manuellen Modus
+// Host hinzufügen - Agent-Hilfe-Hinweis im manuellen Modus
 "ADD_HOST_MANUAL_HINT_TITLE" = "Verbindungsdaten unbekannt?";
 "ADD_HOST_MANUAL_HINT_DESC" = "Sag deinem OpenClaw-Agenten:";
 "ADD_HOST_MANUAL_HINT_PROMPT" = "Installiere den Clawsy-Skill von clawhub";
@@ -349,7 +351,7 @@
 // Agent Identity (named agent dialogs)
 "GENERIC_AGENT" = "Der Agent";
 "AGENT_NAMED_WANTS_TO" = "%@ möchte eine Datei %@.";
-"AGENT_NAMED_WANTS_TO_OP" = "%@ möchte die Datei „%@" %@.";
+"AGENT_NAMED_WANTS_TO_OP" = "%1$@ möchte die Datei „%2$@“ %3$@.";
 "CLIPBOARD_NAMED_WANTS_WRITE" = "%@ möchte in deine Zwischenablage schreiben:";
 "CLIPBOARD_NAMED_WANTS_READ" = "%@ möchte deine Zwischenablage lesen.";
 "ALERT_SCREENSHOT_NAMED_BODY" = "%@ möchte deinen Bildschirm sehen.";

--- a/Sources/ClawsyShared/Resources/en.lproj/Localizable.strings
+++ b/Sources/ClawsyShared/Resources/en.lproj/Localizable.strings
@@ -217,7 +217,9 @@
 "OP_UPLOAD" = "Upload";
 "OP_DOWNLOAD" = "Download";
 "OP_DELETE" = "Delete";
-"AGENT_WANTS_TO_OP" = "The agent wants to %@ the file \"%@\".";
+"AGENT_WANTS_TO_OP" = "The agent wants to %2$@ the file \"%1$@\".";
+"CLIPBOARD_NAMED_WRITE_TITLE" = "%@ wants to write to clipboard";
+"CLIPBOARD_NAMED_READ_TITLE" = "%@ wants to read clipboard";
 "FILENAME_AGENT_STATUS" = "Agent Status (internal)";
 "ALLOW_LIMITED" = "Allow for…";
 "ALLOW_UPLOAD" = "Allow Upload";
@@ -348,7 +350,7 @@
 // Agent Identity (named agent dialogs)
 "GENERIC_AGENT" = "The agent";
 "AGENT_NAMED_WANTS_TO" = "%@ wants to %@ a file.";
-"AGENT_NAMED_WANTS_TO_OP" = "%@ wants to %@ the file \"%@\".";
+"AGENT_NAMED_WANTS_TO_OP" = "%1$@ wants to %3$@ the file \"%2$@\".";
 "CLIPBOARD_NAMED_WANTS_WRITE" = "%@ wants to write to your clipboard:";
 "CLIPBOARD_NAMED_WANTS_READ" = "%@ wants to read your clipboard.";
 "ALERT_SCREENSHOT_NAMED_BODY" = "%@ wants to see your screen.";

--- a/Sources/ClawsyShared/Resources/es.lproj/Localizable.strings
+++ b/Sources/ClawsyShared/Resources/es.lproj/Localizable.strings
@@ -159,7 +159,9 @@
 "ADD_HOST_MODE_TITLE" = "¿Cómo quieres conectarte?";
 "ADD_HOST_SAVE" = "Añadir host";
 "ADD_HOST_TITLE" = "Añadir nuevo host";
-"AGENT_WANTS_TO_OP" = "El agente quiere %@ el archivo «%@».";
+"AGENT_WANTS_TO_OP" = "El agente quiere %2$@ el archivo «%1$@».";
+"CLIPBOARD_NAMED_WRITE_TITLE" = "%@ quiere escribir en el portapapeles";
+"CLIPBOARD_NAMED_READ_TITLE" = "%@ quiere leer el portapapeles";
 "ALLOW_DELETE" = "Permitir eliminación";
 "ALLOW_DOWNLOAD" = "Permitir descarga";
 "ALLOW_GENERIC" = "Permitir";
@@ -301,7 +303,7 @@
 // Agent Identity (named agent dialogs)
 "GENERIC_AGENT" = "El agente";
 "AGENT_NAMED_WANTS_TO" = "%@ quiere %@ un archivo.";
-"AGENT_NAMED_WANTS_TO_OP" = "%@ quiere %@ el archivo «%@».";
+"AGENT_NAMED_WANTS_TO_OP" = "%1$@ quiere %3$@ el archivo «%2$@».";
 "CLIPBOARD_NAMED_WANTS_WRITE" = "%@ quiere escribir en tu portapapeles:";
 "CLIPBOARD_NAMED_WANTS_READ" = "%@ quiere leer tu portapapeles.";
 "ALERT_SCREENSHOT_NAMED_BODY" = "%@ quiere ver tu pantalla.";

--- a/Sources/ClawsyShared/Resources/fr.lproj/Localizable.strings
+++ b/Sources/ClawsyShared/Resources/fr.lproj/Localizable.strings
@@ -159,7 +159,9 @@
 "ADD_HOST_MODE_TITLE" = "Comment voulez-vous vous connecter ?";
 "ADD_HOST_SAVE" = "Ajouter l'hôte";
 "ADD_HOST_TITLE" = "Ajouter un nouvel hôte";
-"AGENT_WANTS_TO_OP" = "L'agent veut %@ le fichier « %@ ».";
+"AGENT_WANTS_TO_OP" = "L'agent veut %2$@ le fichier « %1$@ ».";
+"CLIPBOARD_NAMED_WRITE_TITLE" = "%@ veut écrire dans le presse-papiers";
+"CLIPBOARD_NAMED_READ_TITLE" = "%@ veut lire le presse-papiers";
 "ALLOW_DELETE" = "Autoriser la suppression";
 "ALLOW_DOWNLOAD" = "Autoriser le téléchargement";
 "ALLOW_GENERIC" = "Autoriser";
@@ -301,7 +303,7 @@
 // Agent Identity (named agent dialogs)
 "GENERIC_AGENT" = "L'agent";
 "AGENT_NAMED_WANTS_TO" = "%@ veut %@ un fichier.";
-"AGENT_NAMED_WANTS_TO_OP" = "%@ veut %@ le fichier « %@ ».";
+"AGENT_NAMED_WANTS_TO_OP" = "%1$@ veut %3$@ le fichier « %2$@ ».";
 "CLIPBOARD_NAMED_WANTS_WRITE" = "%@ veut écrire dans votre presse-papiers :";
 "CLIPBOARD_NAMED_WANTS_READ" = "%@ veut lire votre presse-papiers.";
 "ALERT_SCREENSHOT_NAMED_BODY" = "%@ veut voir votre écran.";


### PR DESCRIPTION
## PR #39 Regressions Hotfix

### Bug 1: Format arguments swapped in `fileSyncDescription`
`FileSyncRequestWindow.swift` passed `(agent, operation, filename)` but L10N strings expected `(agent, filename, operation)`.

**Fix:** Swapped arg order in code + added positional format specifiers (`%1$@`, `%2$@`, `%3$@`) to all locale strings for both `AGENT_WANTS_TO_OP` and `AGENT_NAMED_WANTS_TO_OP`.

### Bug 2: Clipboard title replaced by description sentence
PR #39 replaced the short semibold heading `Text(l10n: "CLIPBOARD_WRITE_TITLE")` with `Text(clipboardDescription)` — a full sentence that doesn't belong in the title slot.

**Fix:** New `clipboardTitle` computed property using:
- Existing `CLIPBOARD_WRITE_TITLE` / `CLIPBOARD_READ_TITLE` (fallback)
- New `CLIPBOARD_NAMED_WRITE_TITLE` / `CLIPBOARD_NAMED_READ_TITLE` (with agent name)

### L10N
All changes synced across both bundles (ClawsyMac + ClawsyShared) x 4 locales (en, de, fr, es).