### PR TITLE
chore: apply engineering-standards playbook

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,10 @@ name: Build Clawsy Ecosystem
 
 on:
   push:
-    branches: [ "main", "develop", "v1.0" ]
+    branches: [ "main" ]
     tags: [ "v*" ]
   pull_request:
-    branches: [ "main", "develop" ]
+    branches: [ "main" ]
   workflow_dispatch:
 
 permissions:

--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Pre-push hook: block direct pushes to main/master.
+# Override: ALLOW_PUSH_TO_MAIN=1 git push origin main
+
+if [ "$ALLOW_PUSH_TO_MAIN" = "1" ]; then
+  exit 0
+fi
+
+while read -r _local_ref _local_sha remote_ref _remote_sha; do
+  remote_branch="${remote_ref##refs/heads/}"
+  if [[ "$remote_branch" =~ ^(main|master)$ ]]; then
+    echo ""
+    echo "  BLOCKED: Direct push to '$remote_branch' is not allowed."
+    echo "  Create a feature branch and open a pull request instead."
+    echo ""
+    echo "  Override (emergencies only):"
+    echo "    ALLOW_PUSH_TO_MAIN=1 git push origin $remote_branch"
+    echo ""
+    exit 1
+  fi
+done
+
+exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Agent Instructions
+
+These rules apply to all AI agents working on this repository.
+
+## Git Workflow
+- **Never push directly to `main`.** All changes go through feature branches and pull requests.
+- **Branch naming:** `feat/`, `fix/`, `refactor/`, `docs/`, `chore/` prefixes.
+- **Conventional commits:** `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`, `release:`, `dev:`.
+- **Never force-push** to any shared branch.
+- **Never commit secrets** (.env, API keys, tokens, credentials).
+- **Never skip hooks** (`--no-verify`).
+
+## Pull Requests
+- Keep PR titles short (<70 chars), use conventional prefix.
+- One logical change per PR.
+- Ensure CI passes before requesting merge.
+
+## Pre-push Hook
+A `.hooks/pre-push` hook blocks direct pushes to `main`/`master`. Override only when explicitly instructed:
+```bash
+ALLOW_PUSH_TO_MAIN=1 git push origin main
+```
+
+## Clawsy-specific Rules
+- **No local builds.** Swift is NOT available on the dev machine. Push to CI and watch the build.
+- **Never ask the user to build, run `./build.sh`, or open Xcode.**
+- **Localization:** All user-facing strings use `NSLocalizedString` with `bundle: .clawsy`. Strings go in `Sources/ClawsyShared/Resources/{en,de,fr,es}.lproj/Localizable.strings`.
+- **Bundle resolution:** `.clawsy` resolves to `Clawsy_ClawsyShared.bundle` — localization strings must be in ClawsyShared/Resources, NOT ClawsyMac/Resources.
+- **UI quality bar:** All UI must pass Apple HIG standards — native macOS feel, never developer UI.
+
+## Release Process
+- **Dev/test changes:** Feature branch → PR → merge to main → CI builds artifact
+- **Stable release:** Tag `vX.Y.Z` on main → CI creates GitHub Release with `.zip`
+- Never tag without explicit user instruction.

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+echo "Configuring git hooks..."
+git config core.hooksPath .hooks
+
+echo "Verifying Xcode..."
+if ! xcode-select -p &>/dev/null; then
+  echo "  Xcode not found. Install via: xcode-select --install"
+  echo "  (Clawsy builds run on CI — local Xcode is optional for development)"
+fi
+
+echo "Done. Hooks active, direct pushes to main are blocked."


### PR DESCRIPTION
## Summary
- `.hooks/pre-push` blockiert direkte Pushes auf `main` — erzwingt Feature-Branch + PR Workflow
- `script/setup` — One-Command Dev-Setup (Hooks aktivieren)
- `AGENTS.md` — Git-Workflow, Branching-Regeln, Clawsy-spezifische Anweisungen für AI Agents
- CI Workflow: `v1.0` und `develop` Branch-Trigger entfernt, nur noch `main` + PRs + Tags

## Nach dem Merge
- Branch Protection auf `main` aktivieren (CI required, no direct push)
- Stale Remote-Branches aufräumen (`v1.0`, `develop`, alte Feature-Branches)

## Test plan
- [ ] CI baut erfolgreich auf dem PR
- [ ] Pre-push Hook blockiert `git push origin main`
- [ ] `script/setup` aktiviert Hooks korrekt

🤖 Generated with [Claude Code](https://claude.com/claude-code)