### PR TITLE
feat: disable actions when permissions are missing

### DIFF
--- a/Sources/ClawsyMac/Views/ActionMenuView.swift
+++ b/Sources/ClawsyMac/Views/ActionMenuView.swift
@@ -4,6 +4,7 @@ import ClawsyShared
 /// Main action buttons: QuickSend, Screenshot, Clipboard, Camera.
 struct ActionMenuView: View {
     @ObservedObject var hostManager: HostManager
+    @ObservedObject private var permissionMonitor = PermissionMonitor.shared
     @EnvironmentObject var appDelegate: AppDelegate
 
     @State private var showingScreenshotMenu = false
@@ -12,6 +13,8 @@ struct ActionMenuView: View {
     @AppStorage("activeCameraId", store: SharedConfig.sharedDefaults) private var activeCameraId = ""
 
     private var isConnected: Bool { hostManager.isConnected }
+    private var hasScreenRecording: Bool { permissionMonitor.status[.screenRecording] == true }
+    private var hasCamera: Bool { permissionMonitor.status[.camera] == true }
 
     var body: some View {
         VStack(spacing: 2) {
@@ -25,8 +28,16 @@ struct ActionMenuView: View {
             .frame(maxWidth: .infinity)
 
             // Screenshot
-            Button(action: { showingScreenshotMenu.toggle() }) {
-                MenuItemRow(icon: ClawsyTheme.Icons.screenshot, title: "SCREENSHOT", isEnabled: isConnected, hasChevron: true)
+            Button(action: {
+                if !hasScreenRecording {
+                    permissionMonitor.openSettings(for: .screenRecording)
+                } else {
+                    showingScreenshotMenu.toggle()
+                }
+            }) {
+                MenuItemRow(icon: ClawsyTheme.Icons.screenshot, title: "SCREENSHOT",
+                            subtitle: !hasScreenRecording ? "ACTION_NEEDS_SCREEN_RECORDING" : nil,
+                            isEnabled: isConnected && hasScreenRecording, hasChevron: hasScreenRecording)
             }
             .buttonStyle(.plain)
             .frame(maxWidth: .infinity)
@@ -65,11 +76,17 @@ struct ActionMenuView: View {
 
             // Camera
             Button(action: {
-                ensureCameraSelected()
-                if !availableCameras.isEmpty { showingCameraMenu.toggle() }
+                if !hasCamera {
+                    permissionMonitor.openSettings(for: .camera)
+                } else {
+                    ensureCameraSelected()
+                    if !availableCameras.isEmpty { showingCameraMenu.toggle() }
+                }
             }) {
                 MenuItemRow(icon: ClawsyTheme.Icons.camera, title: "CAMERA",
-                            isEnabled: isConnected && !availableCameras.isEmpty, hasChevron: true)
+                            subtitle: !hasCamera ? "ACTION_NEEDS_CAMERA" : nil,
+                            isEnabled: isConnected && hasCamera && !availableCameras.isEmpty,
+                            hasChevron: hasCamera && !availableCameras.isEmpty)
             }
             .buttonStyle(.plain)
             .frame(maxWidth: .infinity)

--- a/Sources/ClawsyShared/Resources/de.lproj/Localizable.strings
+++ b/Sources/ClawsyShared/Resources/de.lproj/Localizable.strings
@@ -487,5 +487,9 @@
 "UPDATE_AVAILABLE_TITLE" = "Clawsy Update verfügbar";
 "UPDATE_AVAILABLE_BODY %@" = "Version %@ ist bereit. Einstellungen öffnen zum Installieren.";
 
+// Berechtigungshinweise für Aktionen
+"ACTION_NEEDS_SCREEN_RECORDING" = "Bildschirmaufnahme freigeben";
+"ACTION_NEEDS_CAMERA" = "Kamerazugriff freigeben";
+
 // Onboarding
 "ONBOARDING_WINDOW_TITLE" = "Willkommen bei Clawsy";

--- a/Sources/ClawsyShared/Resources/en.lproj/Localizable.strings
+++ b/Sources/ClawsyShared/Resources/en.lproj/Localizable.strings
@@ -486,5 +486,9 @@
 "UPDATE_AVAILABLE_TITLE" = "Clawsy Update Available";
 "UPDATE_AVAILABLE_BODY %@" = "Version %@ is ready. Open Settings to install.";
 
+// Permission-aware action hints
+"ACTION_NEEDS_SCREEN_RECORDING" = "Grant Screen Recording to use";
+"ACTION_NEEDS_CAMERA" = "Grant Camera access to use";
+
 // Onboarding
 "ONBOARDING_WINDOW_TITLE" = "Welcome to Clawsy";

--- a/Sources/ClawsyShared/Resources/es.lproj/Localizable.strings
+++ b/Sources/ClawsyShared/Resources/es.lproj/Localizable.strings
@@ -318,5 +318,9 @@
 "UPDATE_AVAILABLE_TITLE" = "Actualización de Clawsy disponible";
 "UPDATE_AVAILABLE_BODY %@" = "Versión %@ lista. Abre Ajustes para instalar.";
 
+// Indicaciones de permisos para acciones
+"ACTION_NEEDS_SCREEN_RECORDING" = "Conceder grabación de pantalla";
+"ACTION_NEEDS_CAMERA" = "Conceder acceso a la cámara";
+
 // Onboarding
 "ONBOARDING_WINDOW_TITLE" = "Bienvenido a Clawsy";

--- a/Sources/ClawsyShared/Resources/fr.lproj/Localizable.strings
+++ b/Sources/ClawsyShared/Resources/fr.lproj/Localizable.strings
@@ -318,5 +318,9 @@
 "UPDATE_AVAILABLE_TITLE" = "Mise à jour Clawsy disponible";
 "UPDATE_AVAILABLE_BODY %@" = "Version %@ prête. Ouvrir les réglages pour installer.";
 
+// Indications de permission pour les actions
+"ACTION_NEEDS_SCREEN_RECORDING" = "Autoriser l'enregistrement d'écran";
+"ACTION_NEEDS_CAMERA" = "Autoriser l'accès à la caméra";
+
 // Onboarding
 "ONBOARDING_WINDOW_TITLE" = "Bienvenue dans Clawsy";


### PR DESCRIPTION
## Summary
- **Screenshot** button is disabled when Screen Recording permission is not granted, shows localized hint subtitle
- **Camera** button is disabled when Camera permission is not granted, shows localized hint subtitle
- Tapping a disabled action opens the relevant **System Settings** pane (native macOS UX)
- Chevron hidden when action is unavailable (clean visual cue)
- QuickSend and Clipboard unchanged (no TCC permission needed)
- Localized hints in all 4 languages (en/de/fr/es)

## How it works
`ActionMenuView` now observes `PermissionMonitor.shared` (already registered by `ContentView`). Two computed properties (`hasScreenRecording`, `hasCamera`) drive both the `isEnabled` styling and the tap behavior.

## Test plan
- [ ] Revoke Screen Recording → Screenshot shows "Grant Screen Recording to use", tapping opens Settings
- [ ] Grant Screen Recording → Screenshot works normally with chevron
- [ ] Revoke Camera → Camera shows "Grant Camera access to use", tapping opens Settings
- [ ] Grant Camera → Camera works normally
- [ ] Disconnected + no permission → both hints visible, tapping still opens Settings
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)