### PR TITLE
Refactor: Make SettingsView Host-Aware

### DIFF
--- a/Sources/ClawsyMac/Views/SettingsView.swift
+++ b/Sources/ClawsyMac/Views/SettingsView.swift
@@ -52,7 +52,7 @@ struct SettingsTabView: View {
         .frame(width: 480, height: 370)
         .onAppear { loadActiveProfile() }
         .onChange(of: hostManager.activeHostId) { _ in loadActiveProfile() }
-        .onDisappear { saveProfile() }
+        .onChange(of: editedProfile) { _ in saveProfile() }
         .alert("Delete Host?", isPresented: $showDeleteConfirm) {
             Button(NSLocalizedString("CANCEL", bundle: .clawsy, comment: ""), role: .cancel) { hostToDelete = nil }
             Button(NSLocalizedString("DELETE_HOST_CONFIRM", bundle: .clawsy, comment: ""), role: .destructive) {


### PR DESCRIPTION
### Summary

This refactors the `SettingsView` to make it "host-aware", fixing a critical bug where settings were ignored when multiple hosts were configured.

**Problem:**
- The view used global `@AppStorage` for its state.
- The core connection logic reads settings from the active, host-specific `HostProfile`.
- As a result, any changes made in the Settings UI were not applied to the actual connection.

**Solution:**
- Removed all `@AppStorage` dependencies for host-specific settings.
- The view now reads from and writes directly to the active `HostProfile` provided by the `HostManager`.
- An unreliable `.onDisappear` save action was replaced with immediate saving upon change, ensuring data integrity.