### PR TITLE
refactor(onboarding): Use shared HostManager in OnboardingView

### DIFF
--- a/Sources/ClawsyMac/ClawsyApp.swift
+++ b/Sources/ClawsyMac/ClawsyApp.swift
@@ -745,6 +745,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             existing.makeKeyAndOrderFront(nil)
             return
         }
+
+        guard let hostManager = self.hostManager else {
+            os_log("Onboarding skipped: hostManager not initialized", log: OSLog.default, type: .error)
+            return
+        }
+
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 460, height: 540),
             styleMask: [.titled, .closable], backing: .buffered, defer: false)
@@ -763,6 +769,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             onboardingCompleted: onboardingBinding,
             onImportSetupCode: { [weak self] code in self?.handleSetupCode(code) ?? false }
         )
+        .environmentObject(hostManager)
+
         window.contentView = NSHostingView(rootView: view)
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)

--- a/Sources/ClawsyMac/Onboarding/OnboardingView.swift
+++ b/Sources/ClawsyMac/Onboarding/OnboardingView.swift
@@ -13,7 +13,7 @@ struct OnboardingView: View {
 
     @State private var currentPage: OnboardingPage = .welcome
     @ObservedObject private var permissionMonitor = PermissionMonitor.shared
-    @StateObject private var hostManager = HostManager()
+    @EnvironmentObject private var hostManager: HostManager
 
     // Connection fields
     @State private var setupCode = ""


### PR DESCRIPTION
### Summary

This PR fixes Issue #43 by refactoring the `OnboardingView` to use the shared, singleton `HostManager` instance.

**Problem:**
The `OnboardingView` was creating its own `@StateObject` instance of `HostManager`. This led to a separate, inconsistent state from the main application, which uses a shared `HostManager` instance provided to the environment.

**Solution:**
1.  The `OnboardingView` has been modified to receive the `HostManager` as an `@EnvironmentObject`.
2.  The call site in `ClawsyApp.swift` that presents the onboarding sheet now correctly injects the shared `hostManager` instance using the `.environmentObject()` modifier.

This ensures that the onboarding process and the main app operate on the exact same state, preventing bugs related to host management and selection.